### PR TITLE
Rename apply-lens to focus-lens

### DIFF
--- a/lenses/core/base.rkt
+++ b/lenses/core/base.rkt
@@ -7,7 +7,7 @@
 
 (provide let-lens
          make-lens
-         apply-lens
+         focus-lens
          use-applicable-lenses!
          (rename-out [lens-struct? lens?]))
 
@@ -32,14 +32,14 @@
 (define (make-lens getter setter)
   (lens-struct getter setter))
 
-(define (apply-lens lens target)
+(define (focus-lens lens target)
   (match-define (lens-struct get set) lens)
   (values (get target)
           (set target _)))
 
 
 (define-syntax-rule (let-lens (view setter) lens-expr target-expr body ...)
-  (let-values ([(view setter) (apply-lens lens-expr target-expr)])
+  (let-values ([(view setter) (focus-lens lens-expr target-expr)])
     body ...))
 
 (module+ test

--- a/lenses/main.rkt
+++ b/lenses/main.rkt
@@ -13,7 +13,7 @@
    "list/main.rkt"
    "syntax.rkt"
    "syntax-keyword.rkt")
-  apply-lens
+  focus-lens
   drop-lens
   lens-set*
   lens-transform*


### PR DESCRIPTION
Closes #40, no need to bump version as it's not exported yet and thus does not break backwards compatibility
