### PR TITLE
Use deftech to define a ‘lens’ term in the documentation

### DIFF
--- a/lens/main.scrbl
+++ b/lens/main.scrbl
@@ -4,10 +4,10 @@
 
 @defmodule[lens]
 
-This library includes functions and forms for working with @italic{lenses}.
-A lens is a value that operates on some small piece of a larger
-structure. Think of them as a more general representation of getters and
-setters in object-oriented languages.
+This library includes functions and forms for working with
+@deftech[#:key "lens"]{lenses}. A lens is a value that operates on some
+small piece of a larger structure. Think of them as a more general
+representation of getters and setters in object-oriented languages.
 
 @author[@author+email["Jack Firth" "jackhfirth@gmail.com"]]
 


### PR DESCRIPTION
This lets other libraries link to the “lens” term in their documentation.
