### PR TITLE
Use `in-slice` from `racket/sequence`.

### DIFF
--- a/lens/base/transform.rkt
+++ b/lens/base/transform.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require unstable/sequence
-         "base.rkt"
+(require "base.rkt"
          "../util/list-pair-contract.rkt")
 
 (module+ test

--- a/lens/base/view-set.rkt
+++ b/lens/base/view-set.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require unstable/sequence
-         fancy-app
+(require fancy-app
          "base.rkt"
          "../util/list-pair-contract.rkt")
 

--- a/unstable/lens/join.rkt
+++ b/unstable/lens/join.rkt
@@ -2,8 +2,7 @@
 
 (require fancy-app
          lens
-         lens/util/list-pair-contract
-         unstable/sequence)
+         lens/util/list-pair-contract)
 
 (module+ test
   (require rackunit))


### PR DESCRIPTION
This function moved there as of v6.2.900.9.

This change is not compatible with Racket 6.2.1 and prior, which can be fixed by using version exceptions on pkgs.racket-lang.org.

This code will continue working (without this change) in subsequent Racket versions as long as the `unstable-lib` package is installed. This package will eventually not be part of the main distribution, and so would need an explicit dependency (which is a good idea in general). This solution in compatible with Racket 6.2.1 and prior.
