### PR TITLE
fix deps

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -9,6 +9,7 @@
 (define deps
   '("base"
     "rackunit-lib"
+    "unstable-lib"
     "fancy-app"
     "alexis-util"
     "scribble-lib"))


### PR DESCRIPTION
a dependency on “unstable-lib” is required in the current snapshot versions and will be required in future racket versions
