### PR TITLE
put raco cover in after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,6 @@ install: raco pkg install --deps search-auto $TRAVIS_BUILD_DIR # install depende
 
 script:
  - raco test $TRAVIS_BUILD_DIR # run tests. you wrote tests, right?
+
+after_success:
  - raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage . # generate coverage information for coveralls


### PR DESCRIPTION
This makes sure that a `raco cover` failure doesn’t cause the travis build to fail, and allows travis builds on forks that don’t have coveralls set up.
