### PR TITLE
Use scribble-example

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -23,6 +23,7 @@
   '("cover"
     "rackunit-lib"
     "racket-doc"
+    "jack-scribble-example"
     "doc-coverage"))
 
 

--- a/lens/applicable.scrbl
+++ b/lens/applicable.scrbl
@@ -13,7 +13,7 @@ but enables the use of @italic{applicable lenses}. Applicable lenses
 may be used directly as getter functions, removing the need to use
 @racket[lens-view].
 
-@lenses-applicable-examples[
+@lens-applicable-examples[
   (require lens/applicable)
   (first-lens '(a b c))
   (map first-lens '((1 2 3) (a b c) (100 200 300)))
@@ -21,7 +21,7 @@ may be used directly as getter functions, removing the need to use
 
 Attempting to use non-applicable lenses as functions is an error.
 
-@lenses-examples[
+@lens-examples[
   (require lens)
   (first-lens '(a b c))
 ]

--- a/lens/private/base/base.scrbl
+++ b/lens/private/base/base.scrbl
@@ -16,7 +16,7 @@
   @racket[view/c]. The getter must accept a target and return the
   lens's view. The setter must accept a target and a new view, and
   return a new target with its view replaced with the new view.
-  @lenses-examples[
+  @lens-examples[
     (define (set-first lst v)
       (list* v (rest lst)))
     (set-first '(1 2 3) 'a)
@@ -33,7 +33,7 @@
   the target's view to the new view. The context is conceptually
   a function representing the "hole" formed by abstracting the view
   of the target.
-  @lenses-examples[
+  @lens-examples[
     (let-lens (view context) first-lens '(1 2 3)
       (printf "View is ~a\n" view)
       (context 'a))

--- a/lens/private/base/transform.scrbl
+++ b/lens/private/base/transform.scrbl
@@ -15,7 +15,7 @@
   to @racket[transformer], then setting the view of @racket[target]
   to the return value of calling @racket[transformer] with the old
   view.
-  @lenses-examples[
+  @lens-examples[
     (lens-transform first-lens '(1 2 3) number->string)
 ]}
 
@@ -24,7 +24,7 @@
   Like @racket[lens-transform], except that it can take multiple
   lenses-transformer pairs in the same way as @racket[lens-set*]
   and later transformations overwrite earlier ones in the same way.
-  @lenses-examples[
+  @lens-examples[
     (lens-transform/list '(1 2 3 4 5)
                          first-lens number->string
                          third-lens (λ (x) (* 100 x)))

--- a/lens/private/base/view-set.scrbl
+++ b/lens/private/base/view-set.scrbl
@@ -8,21 +8,21 @@
 @defproc[(lens-view [lens lens?] [target target/c]) view/c]{
   Extracts the view of @racket[target] with @racket[lens].
   Essentially a getter function.
-  @lenses-examples[
+  @lens-examples[
     (lens-view first-lens '(1 2 3))
 ]}
 
 @defproc[(lens-set [lens lens?] [target target/c] [new-view view/c]) target/c]{
   Sets the view of @racket[target] to @racket[new-view] using
   @racket[lens]. Essentially a setter function.
-  @lenses-examples[
+  @lens-examples[
     (lens-set first-lens '(1 2 3) 'a)
 ]}
 
 @defproc[(lens-view/list [target target/c] [lens lens?] ...) view/c]{
   Like @racket[lens-view], except that it takes multiple lenses and
   returns a list of views.
-  @lenses-examples[
+  @lens-examples[
     (lens-view/list '(a b c d e f g)
                     first-lens fourth-lens fifth-lens)
 ]}
@@ -31,7 +31,7 @@
   Like @racket[lens-set], except that it can take multiple
   lenses-value pairs. If the view of two of the lenses overlap, the
   later views overwrite the earlier ones.
-  @lenses-examples[
+  @lens-examples[
     (lens-set/list '(1 2 3 4 5)
                    first-lens 10
                    third-lens 300)

--- a/lens/private/compound/compose.scrbl
+++ b/lens/private/compound/compose.scrbl
@@ -10,7 +10,7 @@
   lens's target is viewed through. Each successive lens "zooms in"
   to a more detailed view. When called with no arguments, @racket[lens-compose]
   produces the identity lens.
-  @lenses-examples[
+  @lens-examples[
     (define first-of-second-lens (lens-compose first-lens second-lens))
     (lens-view first-of-second-lens '((1 a) (2 b) (3 c)))
     (lens-set first-of-second-lens '((1 a) (2 b) (3 c)) 200)
@@ -22,7 +22,7 @@
   @racket[(lens-compose lens identity-lens)] and
   @racket[(lens-compose identity-lens lens)] are equivalent to
   @racket[lens].
-  @lenses-examples[
+  @lens-examples[
     (lens-view identity-lens 4)
     (lens-set identity-lens 4 'a)
 ]}

--- a/lens/private/compound/join-hash.scrbl
+++ b/lens/private/compound/join-hash.scrbl
@@ -9,7 +9,7 @@
   as the hash keys. In the same manner as @racket[lens-join/list],
   if lenses share views later lenses take precedence when
   setting.
-  @lenses-examples[
+  @lens-examples[
     (define a-b-lens (lens-join/hash 'a first-lens
                                      'b third-lens))
     (lens-view a-b-lens '(1 2 3))

--- a/lens/private/compound/join-list.scrbl
+++ b/lens/private/compound/join-list.scrbl
@@ -8,7 +8,7 @@
   be used to view and set a list of values in a single
   target. If any of the lenses share views, then when
   setting the later lenses override the earlier ones.
-  @lenses-examples[
+  @lens-examples[
     (define first-third-fifth-lens
       (lens-join/list first-lens
                       third-lens

--- a/lens/private/compound/join-string.scrbl
+++ b/lens/private/compound/join-string.scrbl
@@ -6,7 +6,7 @@
 @defproc[(lens-join/string [lens lens?] ...) lens?]{
   Like @racket[lens-join/list], except the view is a string, not a list.
   Each @racket[lens] argument must return a @racket[char?] as a view.
-  @lenses-examples[
+  @lens-examples[
     (define string-first-third-fifth-lens
       (lens-join/string first-lens
                         third-lens

--- a/lens/private/compound/join-vector.scrbl
+++ b/lens/private/compound/join-vector.scrbl
@@ -5,7 +5,7 @@
 
 @defproc[(lens-join/vector [lens lens?] ...) lens?]{
   Like @racket[lens-join/list], except the view is a vector, not a list.
-  @lenses-examples[
+  @lens-examples[
     (define vector-first-third-fifth-lens
       (lens-join/vector first-lens
                         third-lens

--- a/lens/private/compound/thrush.scrbl
+++ b/lens/private/compound/thrush.scrbl
@@ -7,7 +7,7 @@
   Like @racket[lens-compose], but each @racket[lens] is combined in the
   opposite order. That is, the first @racket[lens] is the first
   @racket[lens] that the compound lens’s target is viewed through.
-  @lenses-examples[
+  @lens-examples[
     (define first-of-second-lens (lens-thrush second-lens first-lens))
     (lens-view first-of-second-lens '((1 a) (2 b) (3 c)))
     (lens-set first-of-second-lens '((1 a) (2 b) (3 c)) 200)

--- a/lens/private/dict.scrbl
+++ b/lens/private/dict.scrbl
@@ -7,7 +7,7 @@
 
 @defproc[(dict-ref-lens [key any/c]) lens?]{
   Returns a lens for viewing the value mapped to @racket[key] in a dict.
-  @lenses-examples[
+  @lens-examples[
     (define dict '((a . 1) (b . 2) (c . 3)))
     (lens-view (dict-ref-lens 'a) dict)
     (lens-set (dict-ref-lens 'a) dict 100)

--- a/lens/private/doc-util/lenses-examples.rkt
+++ b/lens/private/doc-util/lenses-examples.rkt
@@ -1,43 +1,21 @@
-#lang racket
+#lang sweet-exp racket
 
-(provide lenses-examples
-         lenses-applicable-examples
-         lenses-unstable-examples
-         define-persistant-lenses-unstable-examples)
+provide lens-examples
+        lens-applicable-examples
+        lens-unstable-examples
+        persistent-lens-unstable-examples
 
-(require scribble/eval
-         racket/splicing)
+require scribble-example
 
 
-(define-syntax-rule (define-examples-form id require-spec ...)
-  (begin
-    (define (eval-factory)
-      (define base-eval (make-base-eval))
-      (base-eval '(require require-spec)) ...
-      base-eval)
-    (define-syntax-rule (id datum (... ...))
-      (examples #:eval (eval-factory) datum (... ...)))))
-
-(define-syntax-rule (define-examples/persistance-syntax id require-spec ...)
-  (begin
-    (define (eval-factory)
-      (define base-eval (make-base-eval))
-      (base-eval '(require require-spec)) ...
-      base-eval)
-    (define-syntax-rule (id examples-id)
-      (begin
-        (splicing-let ([the-eval (eval-factory)])
-          (define-syntax-rule (examples-id datum (... (... ...)))
-            (examples #:eval the-eval datum (... (... ...)))))))))
-
-(define-examples-form lenses-examples
+(define-examples-form lens-examples
   lens racket/list racket/vector racket/stream racket/set)
 
-(define-examples-form lenses-applicable-examples
+(define-examples-form lens-applicable-examples
   lens/applicable racket/list racket/vector racket/stream racket/set)
 
-(define-examples-form lenses-unstable-examples
+(define-examples-form lens-unstable-examples
   lens unstable/lens racket/list racket/vector racket/stream racket/set)
 
-(define-examples/persistance-syntax define-persistant-lenses-unstable-examples
+(define-persistent-examples-form persistent-lens-unstable-examples
   lens unstable/lens racket/list racket/vector racket/stream racket/set)

--- a/lens/private/hash/nested.scrbl
+++ b/lens/private/hash/nested.scrbl
@@ -7,7 +7,7 @@
   Contructs a lens that targets hashes with nested hashes
   as values and views the value obtained by using each
   @racket[key] in order.
-  @lenses-examples[
+  @lens-examples[
     (define foo-bar-lens (hash-ref-nested-lens 'foo 'bar))
     (lens-view foo-bar-lens (hash 'foo (hash 'bar 1)))
     (lens-set foo-bar-lens (hash 'foo (hash 'bar 1)) 1000)

--- a/lens/private/hash/pick.scrbl
+++ b/lens/private/hash/pick.scrbl
@@ -7,7 +7,7 @@
   Creates a lens that views a subset of the target hash-table with the given
   @racket[key]s. The view, is another hash-table with only the given keys and
   their corrosponding values in the target hash-table.
-  @lenses-examples[
+  @lens-examples[
     (lens-view (hash-pick-lens 'a 'c) (hash 'a 1 'b 2 'c 3))
     (lens-set (hash-pick-lens 'a 'c) (hash 'a 1 'b 2 'c 3) (hash 'a 4 'c 5))
 ]}

--- a/lens/private/hash/ref.scrbl
+++ b/lens/private/hash/ref.scrbl
@@ -6,7 +6,7 @@
 @defproc[(hash-ref-lens [key any/c]) lens?]{
   Constructs a lens that targets hashes and views the value
   of @racket[key].
-  @lenses-examples[
+  @lens-examples[
     (define foo-lens (hash-ref-lens 'foo))
     (lens-view foo-lens (hash 'foo 10 'bar 20))
     (lens-set foo-lens (hash 'foo 10 'bar 20) 1000)

--- a/lens/private/list/assoc.scrbl
+++ b/lens/private/list/assoc.scrbl
@@ -11,7 +11,7 @@
   Specifically, for a given association list the returned
   lens examines the second value of the first pair that
   has a key that is @racket[key-equal?] to @racket[key].
-  @lenses-examples[
+  @lens-examples[
     (define assoc-a-lens (assoc-lens 'a))
     (define some-assoc-list '((a . 1) (b . 2) (c . 3)))
     (lens-view assoc-a-lens some-assoc-list)
@@ -21,7 +21,7 @@
   The @racket[key-equal?] procedure is useful for
   datatypes that have their own definition of
   equality, such as strings.
-  @lenses-examples[
+  @lens-examples[
     (define assoc-foo-lens (assoc-lens "foo" #:is-equal? string=?))
     (lens-view assoc-foo-lens '(("bar" . 1) ("foo" . 2) ("baz" . 3)))
 ]}

--- a/lens/private/list/car-cdr.scrbl
+++ b/lens/private/list/car-cdr.scrbl
@@ -7,7 +7,7 @@
 @deflenses[(car-lens cdr-lens)]{
   Lenses for examining the @racket[car] and @racket[cdr] of
   a pair.
-  @lenses-examples[
+  @lens-examples[
     (lens-view car-lens '(a . b))
     (lens-view cdr-lens '(a . b))
 ]}
@@ -33,7 +33,7 @@
   ddaa ddad ddda dddd)]{
     Lenses for accessing nested pairs. Each lens's view is the
     equivalently named pair-accessor function.
-    @lenses-examples[
+    @lens-examples[
       (cdaddr '(9 8 (6 5 4 3 2 1) 7))
       (lens-view cdaddr-lens '(9 8 (6 5 4 3 2 1) 7))
       (lens-transform cdaddr-lens '(9 8 (6 5 4 3 2 1) 7) list->vector)

--- a/lens/private/list/list-ref-take-drop.scrbl
+++ b/lens/private/list/list-ref-take-drop.scrbl
@@ -10,7 +10,7 @@
          lens?]{
   Returns a lens for viewing the @racket[n]th item of a list,
   with indexing starting from zero.
-  @lenses-examples[
+  @lens-examples[
     (lens-view (list-ref-lens 3) '(a b c d e f g h))
     (lens-set (list-ref-lens 1) '(a b c d e f g h) 'FOO)
 ]}
@@ -27,7 +27,7 @@
             tenth-lens)]{
   Lenses for examiniming specific items of lists. Shorthands
   for the common use cases of @racket[list-ref-lens].
-  @lenses-examples[
+  @lens-examples[
     (lens-view third-lens '(a b c d))
     (lens-view (lens-compose second-lens fourth-lens)
                '((a 1) (b 2) (c 3) (d 4)))

--- a/lens/private/list/multi.scrbl
+++ b/lens/private/list/multi.scrbl
@@ -6,7 +6,7 @@
 @defproc[(list-ref-nested-lens [index exact-nonnegative-integer?] ...) lens?]{
   Constructs a lens that views into a tree made from nested lists.
   Indexing starts from zero in the same was as @racket[list-ref-lens].
-  @lenses-examples[
+  @lens-examples[
     (define first-of-second-lens (list-ref-nested-lens 1 0))
     (lens-view first-of-second-lens '(1 (a b c) 2 3))
     (lens-set first-of-second-lens '(1 (a b c) 2 3) 'foo)
@@ -15,7 +15,7 @@
 @defproc[(list-refs-lens [index exact-nonnegative-integer?] ...) lens?]{
   Constructs a lens that views each @racket[index] item in a list.
   Indexing starts from zero in the same was as @racket[list-ref-lens].
-  @lenses-examples[
+  @lens-examples[
     (define 1-5-6-lens (list-refs-lens 1 5 6))
     (lens-view 1-5-6-lens '(a b c d e f g))
     (lens-set 1-5-6-lens '(a b c d e f g) '(1 2 3))

--- a/lens/private/stream.scrbl
+++ b/lens/private/stream.scrbl
@@ -7,21 +7,21 @@
 
 @defthing[stream-first-lens lens?]{
 A lens for viewing the first element of a stream.
-@lenses-examples[
+@lens-examples[
   (lens-view stream-first-lens (stream 1 2 3))
   (stream->list (lens-set stream-first-lens (stream 1 2 3) 'a))
 ]}
 
 @defthing[stream-rest-lens lens?]{
 A lens for viewing the rest of a stream after the first element.
-@lenses-examples[
+@lens-examples[
   (stream->list (lens-view stream-rest-lens (stream 1 2 3)))
   (stream->list (lens-set stream-rest-lens (stream 1 2 3) (stream 200 300 400 500)))
 ]}
 
 @defproc[(stream-ref-lens [i exact-nonnegative-integer?]) lens?]{
 A lens for viewing the @racket[i]th element of a stream.
-@lenses-examples[
+@lens-examples[
   (lens-view (stream-ref-lens 2) (stream 1 2 3 4 5 6))
   (stream->list (lens-set (stream-ref-lens 2) (stream 1 2 3 4 5 6) 'a))
 ]}

--- a/lens/private/string.scrbl
+++ b/lens/private/string.scrbl
@@ -6,7 +6,7 @@
 
 @defproc[(string-ref-lens [i exact-nonnegative-integer?]) lens?]{
 Returns a lens for viewing the @racket[i]th character of a string.
-@lenses-examples[
+@lens-examples[
   (lens-view (string-ref-lens 2) "abcdef")
   (lens-set (string-ref-lens 2) "abcdef" #\C)
 ]}
@@ -14,7 +14,7 @@ Returns a lens for viewing the @racket[i]th character of a string.
 @defproc[(string-pick-lens [i exact-nonnegative-integer?]) lens?]{
 Like @racket[list-refs-lens], but for strings.
 Equivalent to @racket[(lens-join/string (string-ref-lens i) ...)].
-@lenses-examples[
+@lens-examples[
   (define 1-5-6-lens (string-pick-lens 1 5 6))
   (lens-view 1-5-6-lens "abcdefg")
   (lens-set 1-5-6-lens "abcdefg" "BFG")

--- a/lens/private/struct/field.scrbl
+++ b/lens/private/struct/field.scrbl
@@ -6,7 +6,7 @@
 @defform[(struct-lens struct-id field-id)]{
   Returns a lens for viewing the @racket[field-id] field of
   a @racket[struct-id] instance.
-  @lenses-examples[
+  @lens-examples[
     (struct foo (a b c) #:transparent)
     (lens-view (struct-lens foo a) (foo 1 2 3))
     (lens-set (struct-lens foo a) (foo 1 2 3) 100)

--- a/lens/private/struct/struct.scrbl
+++ b/lens/private/struct/struct.scrbl
@@ -5,7 +5,7 @@
 
 @defform[(define-struct-lenses struct-id)]{
   Given a @racket[struct-id], defines a lens for each of its fields.
-  @lenses-examples[
+  @lens-examples[
     (struct foo (a b c) #:transparent)
     (define-struct-lenses foo)
     (lens-view foo-a-lens (foo 1 2 3))
@@ -14,7 +14,7 @@
 
 @defform[(struct/lens struct-id (field-spec ...) struct-option ...)]{
   Equivalent to @racket[struct] and @racket[define-struct-lenses] combined.
-  @lenses-examples[
+  @lens-examples[
     (struct/lens foo (a b c) #:transparent)
     (lens-view foo-a-lens (foo 1 2 3))
     (lens-set foo-a-lens (foo 1 2 3) 100)

--- a/lens/private/vector/nested.scrbl
+++ b/lens/private/vector/nested.scrbl
@@ -6,7 +6,7 @@
 @defproc[(vector-ref-nested-lens [i exact-nonnegative-integer?] ...) lens?]{
   Like @racket[list-ref-nested-lens], but for vectors.
   Equivalent to @racket[(lens-thrush (vector-ref-lens i) ...)]. 
-  @lenses-examples[
+  @lens-examples[
     (lens-view (vector-ref-nested-lens 2 1) #(a b #(s i) d))
     (lens-set (vector-ref-nested-lens 2 1) #(a b #(s i) d) "eye")
 ]}

--- a/lens/private/vector/pick.scrbl
+++ b/lens/private/vector/pick.scrbl
@@ -6,7 +6,7 @@
 @defproc[(vector-pick-lens [i exact-nonnegative-integer?] ...) lens?]{
   Like @racket[list-refs-lens], but for vectors.
   Equivalent to @racket[(lens-join/vector (vector-ref-lens i) ...)].
-  @lenses-examples[
+  @lens-examples[
     (define 1-5-6-lens (vector-pick-lens 1 5 6))
     (lens-view 1-5-6-lens #(a b c d e f g))
     (lens-set 1-5-6-lens #(a b c d e f g) #(1 2 3))

--- a/lens/private/vector/ref.scrbl
+++ b/lens/private/vector/ref.scrbl
@@ -5,7 +5,7 @@
 
 @defproc[(vector-ref-lens [i exact-nonnegative-integer?]) lens?]{
 Returns a lens that views an element of a vector.
-@lenses-examples[
+@lens-examples[
   (lens-view (vector-ref-lens 2) #(a b c d))
   (lens-set (vector-ref-lens 2) #(a b c d) "sea")
 ]}

--- a/unstable/lens/arrow.scrbl
+++ b/unstable/lens/arrow.scrbl
@@ -16,7 +16,7 @@ switched, so that the @racket[target] comes first and the
 @racket[(lens-view (lens-thrush lens ...) target)], but can be more		
 efficient.
 The function @racket[lens-view~>] is provided as a shorter version.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view/thrush '(a b ((c d) e f) g) third-lens first-lens second-lens)
   (lens-view~> '(a b ((c d) e f) g) third-lens first-lens second-lens)
 ]}
@@ -28,7 +28,7 @@ which again are combined into a nested lens.
 @racket[(lens-set/thrush target lens ... #:-> new-view)] is equivalent
 to @racket[(lens-set (lens-thrush lens ...) target new-view)], and
 @racket[lens-set~>] is the shorter version.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-set/thrush '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> "sea")
   (lens-set~> '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> "sea")
 ]}
@@ -45,7 +45,7 @@ just like @racket[lens-set/thrush].
 equivalent to
 @racket[(lens-transform (lens-thrush lens ...) target transformer)],
 and @racket[lens-transform~>] is the shorter verison.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-transform/thrush '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> symbol->string)
   (lens-transform~> '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> symbol->string)
 ]}

--- a/unstable/lens/if.scrbl
+++ b/unstable/lens/if.scrbl
@@ -13,7 +13,7 @@
 Creates a lens that uses @racket[lens1] when the target satisfies
 @racket[pred], and uses @racket[lens2] when the target doesn't satisfy
 @racket[pred].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (define if-lens (lens-if list? first-lens (vector-ref-lens 0)))
   (lens-view if-lens '(1 2 3))
   (lens-view if-lens '#(1 2 3))
@@ -27,7 +27,7 @@ Creates a lens that uses @racket[lens1] when the target satisfies
 Like @racket[lens-if], but based on @racket[cond] instead of
 @racket[if]. It creates a lens that uses the first lens if the target matches the first
 predicate, the second lens if the target matches the second predicate, and so on.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (define cond-lens (lens-cond [list? first-lens]
                                [vector? (vector-ref-lens 0)]
                                [string? (string-ref-lens 0)]))
@@ -45,7 +45,7 @@ matching the target against each @racket[pat] with @racket[match].
 It creates a lens that uses the first lens if the target matches the
 first @racket[pat], the second lens if it matches the second
 @racket[pat], and so on.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (define lens (lens-match [(list a) first-lens]
                            [(list a b) second-lens]))
   (lens-view lens '(1))

--- a/unstable/lens/isomorphism.scrbl
+++ b/unstable/lens/isomorphism.scrbl
@@ -17,7 +17,7 @@ So for instance a @racket[symbol->string-lens] could be defined with:
   (define symbol->string-lens
     (make-isomorphism-lens symbol->string string->symbol))
 ]
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view symbol->string-lens 'something)
   (lens-transform symbol->string-lens 'something (λ (s) (string-append "make-" s)))
 ]}

--- a/unstable/lens/mapper.scrbl
+++ b/unstable/lens/mapper.scrbl
@@ -8,7 +8,7 @@
 
 @defproc[(mapper-lens [lens lens?]) lens?]{
 Creates a lens that maps @racket[lens] over a target list.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (mapper-lens first-lens) '((a b) (c d) (e f)))
   (lens-set (mapper-lens first-lens) '((a b) (c d) (e f)) '(1 2 3))
   (lens-transform (mapper-lens first-lens) '((a b) (c d) (e f)) (λ (xs) (map symbol->string xs)))
@@ -16,7 +16,7 @@ Creates a lens that maps @racket[lens] over a target list.
 
 @defproc[(vector-mapper-lens [lens lens?]) lens?]{
 Creates a lens that maps @racket[lens] over a target vector with @racket[vector-map].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (vector-mapper-lens first-lens) '#((a b) (c d) (e f)))
   (lens-set (vector-mapper-lens first-lens) '#((a b) (c d) (e f)) '#(1 2 3))
   (lens-transform (vector-mapper-lens first-lens) '#((a b) (c d) (e f))

--- a/unstable/lens/match.scrbl
+++ b/unstable/lens/match.scrbl
@@ -10,7 +10,7 @@ Creates a lens for viewing the @racket[id] within the @racket[pattern].
 The @racket[replacement] expression should be an expression such that
 @racket[(match target [pattern replacement])] produces a value equivalent to
 @racket[target], and should use @racket[id] as the view.
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (define car-lens (match-lens a (cons a b) (cons a b)))
   (define cdr-lens (match-lens b (cons a b) (cons a b)))
   (define third-lens (match-lens c (list a b c d ...) (list* a b c d)))

--- a/unstable/lens/set-filterer.scrbl
+++ b/unstable/lens/set-filterer.scrbl
@@ -8,14 +8,14 @@
 
 @defproc[(set-filterer-lens [pred (-> any/c any/c)]) (lens/c functional-set? functional-set?)]{
 Creates a lens that filters a set by the predicate @racket[pred].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (set-filterer-lens number?) (set 1 'a 2 'b 'c 3 'd 'e))
   (lens-set (set-filterer-lens number?) (set 1 'a 2 'b 'c 3 'd 'e) (set 4 5 6 7))
 ]
 Lists are also sets, so @racket[set-filterer-lens] works for lists too, but it
 does not preserve ordering. It follows the lens laws only if you compare using
 @racket[set=?], not @racket[equal?].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (set-filterer-lens number?) '(a 1 2 3)) ; will be '(1 2 3)
   (lens-set (set-filterer-lens number?) '(a 1 2 3) '(1 2 3)) ; will be '(3 2 1 a)
   (code:comment "this breaks the lens laws according to equal?")

--- a/unstable/lens/string-split.scrbl
+++ b/unstable/lens/string-split.scrbl
@@ -9,7 +9,7 @@
 @defproc[(string-split-lens [sep (or/c string? char? regexp?)]) lens?]{
 Creates a lens that splits a string into multiple pieces like
 @racket[regexp-split] or @racket[string-split].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (string-split-lens ",") "a,b,c")
   (lens-set (string-split-lens ",") "a,b,c" '("1" "2" "3"))
 ]
@@ -18,7 +18,7 @@ when viewing a target that either starts or ends with something matching
 @racket[sep], the view will include empty strings as the first or last element,
 which is consistant with @racket[regexp-split] or @racket[string-split] with
 @racket[#:trim? #f]. This is also more useful when using @racket[lens-set].
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (string-split-lens ",") ",b,c")
   (lens-set (string-split-lens ",") ",b,c" '("a" "b" "c"))
   (lens-view (string-split-lens ",") "a,b,c,")

--- a/unstable/lens/struct-join.scrbl
+++ b/unstable/lens/struct-join.scrbl
@@ -12,7 +12,7 @@
 Like @racket[lens-join/list], except that the views of the given
 lenses are put in an instance of the @racket[struct-id] struct instead
 of in a list. 
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (struct foo (a b) #:transparent)
   (define lens (lens-join/struct foo first-lens third-lens))
   (lens-view lens '(1 2 3))
@@ -21,7 +21,7 @@ of in a list.
 Struct fields in a @racket[lens-join/struct] form can also be
 specified by keywords, in any order, and even with some fields specied
 by position and some by keywords:
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (struct foo (a b) #:transparent)
   (lens-view (lens-join/struct foo first-lens third-lens) '(1 2 3))
   (lens-view (lens-join/struct foo #:a first-lens #:b third-lens) '(1 2 3))

--- a/unstable/lens/struct-nested.scrbl
+++ b/unstable/lens/struct-nested.scrbl
@@ -6,7 +6,7 @@
 
 @defmodule[unstable/lens/struct-nested]
 
-@(define-persistant-lenses-unstable-examples struct-nested-examples)
+@(persistent-lens-unstable-examples struct-nested-examples)
 
 @defform[#:id struct-nested-lens
          (struct-nested-lens [struct-id field-id] ...)]{
@@ -36,7 +36,7 @@
     (lens-set game-player-health-lens the-game 20)
 ]}
 
-@(define-persistant-lenses-unstable-examples struct-nested*-examples)
+@(persistent-lens-unstable-examples struct-nested*-examples)
 
 @defform[#:id struct-nested-lens*
          (struct-nested-lens* struct-id both-id ... field-id)]{

--- a/unstable/lens/sublist.scrbl
+++ b/unstable/lens/sublist.scrbl
@@ -7,7 +7,7 @@
 @defmodule[unstable/lens/sublist]
 
 @defproc[(sublist-lens [i exact-nonnegative-integer?] [j exact-nonnegative-integer?]) lens?]{
-@lenses-unstable-examples[
+@lens-unstable-examples[
   (lens-view (sublist-lens 1 4) '(0 1 2 3 4 5))
   (lens-set (sublist-lens 1 4) '(0 1 2 3 4 5) '(a b c))
 ]}

--- a/unstable/lens/syntax.scrbl
+++ b/unstable/lens/syntax.scrbl
@@ -11,7 +11,7 @@
   Constructs a lens that parses a syntax object and returns
   a piece of that syntax object as determined by where
   @racket[target-id] appears in @racket[structure].
-  @lenses-unstable-examples[
+  @lens-unstable-examples[
     (define first-of-second-stx-lens
       (syntax-lens A
         (_ (A _ ...) _ ...)))
@@ -28,7 +28,7 @@
   and views a syntax object containing all the terms in the
   target syntax that appear after @racket[kw] but before any
   other keyword.
-  @lenses-unstable-examples[
+  @lens-unstable-examples[
     (define foo-kw-seq-lens (syntax-keyword-seq-lens '#:foo))
     (lens-view foo-kw-seq-lens #'(a #:foo c d #:bar f))
     (lens-set foo-kw-seq-lens #'(a #:foo c d #:bar f) #'(1 2 3 4 5 6))
@@ -39,7 +39,7 @@
   object or immediately followed by another keyword, then viewing
   produces the empty list syntax object @racket[#'()]. In the case
   where @racket[kw] is not present, setting is a no-op.
-  @lenses-unstable-examples[
+  @lens-unstable-examples[
     (define foo-kw-seq-lens (syntax-keyword-seq-lens '#:foo))
     (lens-view foo-kw-seq-lens #'(a b f g))
     (lens-view foo-kw-seq-lens #'(a #:foo #:bar f))

--- a/unstable/lens/view-set.scrbl
+++ b/unstable/lens/view-set.scrbl
@@ -7,7 +7,7 @@
 
 @defproc[(lens-set-all [target any/c] [new-view any/c] [lens lens?] ...) any/c]{
   Sets the view of @racket[target] through each @racket[lens] to @racket[new--view]
-  @lenses-unstable-examples[
+  @lens-unstable-examples[
     (lens-set-all '(1 2 3 4 5) 'a
                   first-lens
                   third-lens


### PR DESCRIPTION
This factors out example form creation into a separate package (jack-scribble-example) and also renames the example forms to match the package name
