### PR TITLE
Remove dependency on `unstable/contract`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,10 +7,9 @@
 
 
 (define deps
-  '("base"
+  '(("base" #:version "6.2.900.15")
     "rackunit-lib"
     "unstable-lib"
-    "unstable-contract-lib"
     "fancy-app"
     "alexis-util"
     "sweet-exp"

--- a/lens/private/base/contract.rkt
+++ b/lens/private/base/contract.rkt
@@ -3,7 +3,6 @@
 (provide lens/c)
 
 (require racket/contract/base
-         unstable/contract
          "gen-lens.rkt"
          )
 (module+ test


### PR DESCRIPTION
Most of the functionality of that library has been moved to `racket/contract`, and `unstable/contract` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2.1-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-contract-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please keep a dependency to `unstable-contract-lib`.
