### PR TITLE
fix possible loops with fallback methods

### DIFF
--- a/lens/private/base/gen-lens.rkt
+++ b/lens/private/base/gen-lens.rkt
@@ -19,15 +19,24 @@
   (lens-view lens target)
   (lens-set lens target x)
   (focus-lens lens target)
+  #:defined-predicate lens-implements?
   #:fallbacks
   [(define/generic gen-lens-view lens-view)
    (define/generic gen-lens-set lens-set)
+   (define/generic gen-focus-lens focus-lens)
    (define (lens-view lens target)
-     (let-lens (view _) lens target view))
+     (unless (lens-implements? lens 'focus-lens)
+       (error 'lens-view "not implemented for ~v" lens))
+     (let-values ([(view _) (gen-focus-lens lens target)])
+       view))
    (define (lens-set lens target x)
-     (let-lens (_ setter) lens target
+     (unless (lens-implements? lens 'focus-lens)
+       (error 'lens-set "not implemented for ~v" lens))
+     (let-values ([(_ setter) (gen-focus-lens lens target)])
        (setter x)))
    (define (focus-lens lens target)
+     (unless (lens-implements? lens 'lens-view 'lens-set)
+       (error 'focus-lens "not implemented for ~v" lens))
      (values (gen-lens-view lens target)
              (gen-lens-set lens target _)))]
   #:derive-property prop:procedure

--- a/lens/private/tests/gen-lens-fallback-loop.rkt
+++ b/lens/private/tests/gen-lens-fallback-loop.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+(require lens/private/base/gen-lens
+         rackunit
+         racket/function)
+
+(struct bad1 ()
+  #:methods gen:lens [])
+(check-exn #rx"lens-view: not implemented"
+           (thunk (lens-view (bad1) 1)))
+(check-exn #rx"lens-set: not implemented"
+           (thunk (lens-set (bad1) 1 1)))
+(check-exn #rx"focus-lens: not implemented"
+           (thunk (focus-lens (bad1) 1)))
+
+(struct bad2 ()
+  #:methods gen:lens
+  [(define (lens-view this tgt) "something")])
+(check-equal? (lens-view (bad2) 1) "something")
+(check-exn #rx"lens-set: not implemented"
+           (thunk (lens-set (bad2) 1 1)))
+(check-exn #rx"focus-lens: not implemented"
+           (thunk (focus-lens (bad2) 1)))
+
+(struct bad3 ()
+  #:methods gen:lens
+  [(define (lens-set this tgt nvw) tgt)])
+(check-equal? (lens-set (bad3) 1 2) 1)
+(check-exn #rx"lens-view: not implemented"
+           (thunk (lens-view (bad3) 1)))
+(check-exn #rx"focus-lens: not implemented"
+           (thunk (focus-lens (bad3) 1)))


### PR DESCRIPTION
These would come up if someone defined a struct that declared only
lens-view or only lens-set, or no methods at all.
