### PR TITLE
Allow RACKET_HEAD build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   allow_failures:
     - env: RACKET_VERSION=HEAD
-      env: VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
+           VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
       VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
 matrix:
   allow_failures:
-    - env: RACKET_VERSION=HEAD
+    - env: "RACKET_VERSION=HEAD"
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
       VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
 matrix:
   allow_failures:
-    - env: "RACKET_VERSION=HEAD"
+    - env: RACKET_VERSION=HEAD
+      env: VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
       VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
     - RACKET_VERSION=HEAD
       VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
+matrix:
+  allow_failures:
+    - env: RACKET_VERSION=HEAD
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket


### PR DESCRIPTION
RACKET_HEAD is a touch too unstable to keep on top of. We'll aim to have as many releases as possible build successfully, while keeping a watch on HEAD.
