### PR TITLE
Add dependency on unstable-list-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -11,6 +11,7 @@
     "base"
     "rackunit-lib"
     "unstable-lib"
+    "unstable-list-lib"
     "unstable-contract-lib"
     "fancy-app"
     "alexis-util"


### PR DESCRIPTION
for unstable/hash, used in unstable/lens/hash-filterer.rkt
