### PR TITLE
Add an initial stab at a “lens guide”

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 **/compiled/*
 **/*.bak
 **/*.html
-**/*.css
 **/*.js
 *~
 **.rktd

--- a/lens/main.scrbl
+++ b/lens/main.scrbl
@@ -7,9 +7,9 @@
 @defmodule[lens]
 
 This library includes functions and forms for working with
-@deftech[#:key "lens"]{lenses}. A lens is a value that operates on some
-small piece of a larger structure. Think of them as a more general
-representation of getters and setters in object-oriented languages.
+@lens-tech{lenses}. A lens is a value that operates on some small piece
+of a larger structure. Think of them as a more general representation
+of getters and setters in object-oriented languages.
 
 @author[@author+email["Jack Firth" "jackhfirth@gmail.com"]
         @author+email["Alex Knauth" "alexander@knauth.org"]]
@@ -20,14 +20,5 @@ source code: @url["https://github.com/jackfirth/lens"]
 
 @local-table-of-contents[]
 
-@secref{unstable/lens}
-@include-section["private/base/main.scrbl"]
-@include-section["private/compound/main.scrbl"]
-@include-section["private/list/main.scrbl"]
-@include-section["private/hash/main.scrbl"]
-@include-section["private/struct/main.scrbl"]
-@include-section["private/vector/main.scrbl"]
-@include-section["private/string.scrbl"]
-@include-section["private/stream.scrbl"]
-@include-section["private/dict.scrbl"]
-@include-section["applicable.scrbl"]
+@include-section["private/scribblings/guide.scrbl"]
+@include-section["private/scribblings/reference.scrbl"]

--- a/lens/private/base/laws.scrbl
+++ b/lens/private/base/laws.scrbl
@@ -2,7 +2,7 @@
 
 @(require "../doc-util/main.rkt")
 
-@title{Lens Laws}
+@title[#:tag "laws"]{Lens Laws}
 
 While @racket[make-lens] allows lenses to be constructed
 from arbitrary getters and setters, these getters and setters

--- a/lens/private/compound/main.scrbl
+++ b/lens/private/compound/main.scrbl
@@ -2,7 +2,7 @@
 
 @(require "../doc-util/scribble-include-no-subsection.rkt")
 
-@title{Joining and Composing Lenses}
+@title[#:tag "composing-lenses"]{Joining and Composing Lenses}
 
 @scribble-include/no-subsection["compose.scrbl"]
 @scribble-include/no-subsection["thrush.scrbl"]

--- a/lens/private/dict.scrbl
+++ b/lens/private/dict.scrbl
@@ -3,7 +3,9 @@
 @(require "doc-util/main.rkt")
 
 
-@title{Dict lenses}
+@title[#:tag "dict-reference"]{Dict lenses}
+
+@see-guide-note["dict-guide"]{dictionary lenses}
 
 @defproc[(dict-ref-lens [key any/c]) lens?]{
   Returns a lens for viewing the value mapped to @racket[key] in a dict.

--- a/lens/private/doc-util/lens-tech.rkt
+++ b/lens/private/doc-util/lens-tech.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(require scribble/manual)
+
+(provide lens-tech)
+
+(define (lens-tech . pre-content)
+  (apply tech #:key "lens" #:normalize? #f pre-content))

--- a/lens/private/doc-util/main.rkt
+++ b/lens/private/doc-util/main.rkt
@@ -2,7 +2,9 @@
 syntax/parse/define
 "deflenses.rkt"
 "include-sections.rkt"
+"lens-tech.rkt"
 "lenses-examples.rkt"
+"other-reference.rkt"
 "stability-notice.rkt"
 for-label
   lens

--- a/lens/private/doc-util/main.rkt
+++ b/lens/private/doc-util/main.rkt
@@ -16,6 +16,7 @@ for-label
   racket/stream
   racket/set
   racket/contract
+  racket/function
 for-syntax
   racket/base
   syntax/parse

--- a/lens/private/doc-util/other-reference.css
+++ b/lens/private/doc-util/other-reference.css
@@ -1,0 +1,19 @@
+.flexible-container {
+  display: -webkit-flex;
+  display: flex;
+}
+
+.flexible-element {
+  -webkit-flex: 1;
+  flex: 1;
+}
+
+.margin-note__image-left {
+  float: left;
+  font-size: 1.25em;
+  margin-right: 0.4em;
+}
+
+.margin-note__image-left--finger::before {
+  content: '☞';
+}

--- a/lens/private/doc-util/other-reference.rkt
+++ b/lens/private/doc-util/other-reference.rkt
@@ -1,0 +1,25 @@
+#lang at-exp racket/base
+
+(require racket/require
+         (multi-in scribble (base html-properties struct))
+         (only-in scribble/core style)
+         setup/collects)
+
+(provide other-reference-note)
+
+(define css-resource
+  (make-css-addition
+   (path->collects-relative
+    (collection-file-path "other-reference.css" "lens" "private" "doc-util"))))
+
+(define finger (element (style "margin-note__image-left margin-note__image-left--finger"
+                               (list css-resource))
+                        '()))
+
+(define (flexible-container . content)
+  (element (style "flexible-container" (list css-resource (alt-tag "div"))) content))
+(define (flexible-element . content)
+  (element (style "flexible-element" (list css-resource (alt-tag "div"))) content))
+
+(define (other-reference-note . pre-content)
+  (margin-note (flexible-container finger (apply flexible-element pre-content))))

--- a/lens/private/doc-util/other-reference.rkt
+++ b/lens/private/doc-util/other-reference.rkt
@@ -5,7 +5,7 @@
          (only-in scribble/core style)
          setup/collects)
 
-(provide other-reference-note)
+(provide other-reference-note see-guide-note see-reference-note)
 
 (define css-resource
   (make-css-addition
@@ -23,3 +23,11 @@
 
 (define (other-reference-note . pre-content)
   (margin-note (flexible-container finger (apply flexible-element pre-content))))
+
+(define (see-guide-note tag . pre-content)
+  @other-reference-note{
+    @seclink[tag]{The Lens Guide} has additional examples of @|pre-content|.})
+
+(define (see-reference-note tag . pre-content)
+  @other-reference-note{
+    @seclink[tag]{The Lens Reference} has additional information on @|pre-content|.})

--- a/lens/private/hash/main.scrbl
+++ b/lens/private/hash/main.scrbl
@@ -1,8 +1,11 @@
 #lang scribble/manual
 
-@(require "../doc-util/scribble-include-no-subsection.rkt")
+@(require "../doc-util/main.rkt"
+          "../doc-util/scribble-include-no-subsection.rkt")
 
-@title{Hash Lenses}
+@title[#:tag "hash-reference"]{Hash Lenses}
+
+@see-guide-note["hash-guide"]{hash lenses}
 
 @scribble-include/no-subsection["ref.scrbl"]
 @scribble-include/no-subsection["nested.scrbl"]

--- a/lens/private/list/car-cdr.scrbl
+++ b/lens/private/list/car-cdr.scrbl
@@ -2,7 +2,7 @@
 
 @(require "../doc-util/main.rkt")
 
-@title{Pair lenses}
+@title[#:tag "pair-lenses"]{Pair lenses}
 
 @deflenses[(car-lens cdr-lens)]{
   Lenses for examining the @racket[car] and @racket[cdr] of

--- a/lens/private/list/main.scrbl
+++ b/lens/private/list/main.scrbl
@@ -1,6 +1,10 @@
 #lang scribble/manual
 
-@title{Pair and List Lenses}
+@(require "../doc-util/main.rkt")
+
+@title[#:tag "pair-list-reference"]{Pair and List Lenses}
+
+@see-guide-note["pair-list-guide"]{pair and list lenses}
 
 @include-section["car-cdr.scrbl"]
 @include-section["list-ref-take-drop.scrbl"]

--- a/lens/private/scribblings/guide.scrbl
+++ b/lens/private/scribblings/guide.scrbl
@@ -11,3 +11,4 @@ features this library provides; for a complete API reference, see @secref{lens-r
 
 @include-section["guide/introduction.scrbl"]
 @include-section["guide/built-in.scrbl"]
+@include-section["guide/user-defined.scrbl"]

--- a/lens/private/scribblings/guide.scrbl
+++ b/lens/private/scribblings/guide.scrbl
@@ -4,8 +4,8 @@
 
 This guide is intended for programmers who are familiar with Racket but new to working with lenses or
 a certain part of this lens library. It contains a non-authorative introduction to lenses, including
-examples of usage and recipies for solving certain kinds of problems. It does not describe all
-features this library provides; for a complete API reference, see @secref{lens-reference}.
+examples of usage and recipes for solving certain kinds of problems. It does not describe all features
+this library provides; for a complete API reference, see @secref{lens-reference}.
 
 @local-table-of-contents[]
 

--- a/lens/private/scribblings/guide.scrbl
+++ b/lens/private/scribblings/guide.scrbl
@@ -1,0 +1,12 @@
+#lang scribble/manual
+
+@title[#:tag "lens-guide" #:style 'toc]{The Lens Guide}
+
+This guide is intended for programmers who are familiar with Racket but new to working with lenses or
+a certain part of this lens library. It contains a non-authorative introduction to lenses, including
+examples of usage and recipies for solving certain kinds of problems. It does not describe all
+features this library provides; for a complete API reference, see @secref{lens-reference}.
+
+@local-table-of-contents[]
+
+@include-section["guide/introduction.scrbl"]

--- a/lens/private/scribblings/guide.scrbl
+++ b/lens/private/scribblings/guide.scrbl
@@ -10,3 +10,4 @@ features this library provides; for a complete API reference, see @secref{lens-r
 @local-table-of-contents[]
 
 @include-section["guide/introduction.scrbl"]
+@include-section["guide/built-in.scrbl"]

--- a/lens/private/scribblings/guide/built-in.scrbl
+++ b/lens/private/scribblings/guide/built-in.scrbl
@@ -1,15 +1,8 @@
 #lang scribble/manual
 
-@(require scribble/eval
-          "../../doc-util/main.rkt")
+@(require "../../doc-util/main.rkt")
 
-@(define make-lens-eval
-   (make-eval-factory '(racket/base lens)))
-
-@(define-syntax-rule (lens-interaction expr ...)
-   (interaction #:eval (make-lens-eval) expr ...))
-
-@title[#:tag "builtin-lenses" #:style 'toc]{Lenses on Built-In Datatypes}
+@title[#:tag "built-in-lenses" #:style 'toc]{Lenses on Built-In Datatypes}
 
 This library provides @lens-tech{lenses} for most built-in Racket datatypes. In general the name of
 each lens corresponds to the name of its accessor function, with @racket[-lens] appended to the end.

--- a/lens/private/scribblings/guide/built-in.scrbl
+++ b/lens/private/scribblings/guide/built-in.scrbl
@@ -4,8 +4,8 @@
 
 @title[#:tag "built-in-lenses" #:style 'toc]{Lenses on Built-In Datatypes}
 
-This library provides @lens-tech{lenses} for most built-in Racket datatypes. In general the name of
-each lens corresponds to the name of its accessor function, with @racket[-lens] appended to the end.
+This library provides @lens-tech{lenses} for most built-in Racket datatypes. In general, the name of
+each lens corresponds to the name of its accessor function with @racket[-lens] appended to the end.
 For example, the lens for accessing the first element of a pair is @racket[car-lens], and the lens for
 accessing an element of a hash is called @racket[hash-ref-lens].
 

--- a/lens/private/scribblings/guide/built-in.scrbl
+++ b/lens/private/scribblings/guide/built-in.scrbl
@@ -9,6 +9,14 @@
 @(define-syntax-rule (lens-interaction expr ...)
    (interaction #:eval (make-lens-eval) expr ...))
 
-@title[#:tag "builtin-lenses"]{Lenses on Built-In Datatypes}
+@title[#:tag "builtin-lenses" #:style 'toc]{Lenses on Built-In Datatypes}
 
+This library provides @lens-tech{lenses} for most built-in Racket datatypes. In general the name of
+each lens corresponds to the name of its accessor function, with @racket[-lens] appended to the end.
+For example, the lens for accessing the first element of a pair is @racket[car-lens], and the lens for
+accessing an element of a hash is called @racket[hash-ref-lens].
 
+@local-table-of-contents[]
+
+@include-section["built-in/ordered.scrbl"]
+@include-section["built-in/key-value.scrbl"]

--- a/lens/private/scribblings/guide/built-in.scrbl
+++ b/lens/private/scribblings/guide/built-in.scrbl
@@ -1,0 +1,14 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../doc-util/main.rkt")
+
+@(define make-lens-eval
+   (make-eval-factory '(racket/base lens)))
+
+@(define-syntax-rule (lens-interaction expr ...)
+   (interaction #:eval (make-lens-eval) expr ...))
+
+@title[#:tag "builtin-lenses"]{Lenses on Built-In Datatypes}
+
+

--- a/lens/private/scribblings/guide/built-in/key-value.scrbl
+++ b/lens/private/scribblings/guide/built-in/key-value.scrbl
@@ -1,0 +1,90 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../../doc-util/main.rkt")
+
+@(define make-lens-eval
+   (make-eval-factory '(racket/base lens)))
+
+@(define-syntax-rule (lens-interaction expr ...)
+   (interaction #:eval (make-lens-eval) expr ...))
+
+@title[#:tag "key-value-lenses"]{Lenses on Key-Value Data}
+
+Many Racket data structures hold values that correspond to a given key. Lenses for accessing elements
+of these structures by their keys are provided.
+
+@section[#:tag "hash-guide"]{Hash Tables}
+
+@see-reference-note["hash-reference"]{hash lenses}
+
+Racket hash tables are simple key-value associations, and as a result, they only have one primitive
+lens constructor, @racket[hash-ref-lens]. Given a key, it produces a lens which views the value
+associated with the lens:
+
+@(lens-interaction
+  (lens-transform (hash-ref-lens 'a) (hash 'a "Hello")
+                  (λ (s) (string-append s ", world!"))))
+
+Note that @racket[hash-ref-lens]'s signature differs from that of @racket[hash-ref] in an important
+way: it does not accept a "failure result" if the key is missing from the hash. Instead, the lens
+always throws an error:
+
+@(lens-interaction
+  (lens-view (hash-ref-lens 'not-a-key) (hash)))
+
+This may seem inconvenient, but this limitation is by design---supporting a failure result would
+violate one of the @seclink["laws"]{lens laws}. Specifically, “get-set consistency” would no longer
+hold. Consider this example:
+
+@(racketblock
+  (let ([l (hash-ref-lens 'not-a-key "default")]
+        [h (hash)])
+    (lens-set l h (lens-view l h))))
+
+If @racket[hash-ref-lens] accepted a default value, then the above expression would produce a new hash
+that was not @racket[equal?] to the original target. Enforcing this property makes lenses easier to
+reason about, just as ensuring purity makes functions easier to reason about.
+
+Of course, sometimes breaking purity is the easiest way to solve a problem, and similarly, sometimes
+breaking the lens laws is okay (though it should be avoided if possible). We could, if we wished,
+define our own hash lens that accepts a default value:
+
+@(define ref-default-eval (make-lens-eval))
+@(interaction #:eval ref-default-eval
+  (define (hash-ref-lens/default key failure-result)
+    (make-lens (λ (h)   (hash-ref h key failure-result))
+               (λ (h v) (hash-set h key v)))))
+
+With this custom, "naughty" lens, we can actually perform the example from above:
+
+@(interaction #:eval ref-default-eval
+  (let ([l (hash-ref-lens/default 'not-a-key "default")]
+        [h (hash)])
+    (lens-set l h (lens-view l h))))
+
+In addition to @racket[hash-ref-lens], @racket[hash-ref-nested-lens] is provided, which assists in
+fetching values from nested hashes. It is defined in terms of @racket[hash-ref-lens] and
+@racket[lens-compose], so it is just a shorter way of expressing the same concept:
+
+@(lens-interaction
+  (lens-set (hash-ref-nested-lens 'a 'b 'c)
+            (hash 'a (hash 'b (hash 'c "foo")))
+            "bar"))
+
+@section[#:tag "dict-guide"]{Dictionaries}
+
+@see-reference-note["dict-reference"]{dictionary lenses}
+
+Racket @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{dictionaries} provide a generic
+interface for many kinds of key-value data-structures. They encompass hash tables, association lists,
+user-defined dictionaries, and even integer-keyed structures like vectors.
+
+In practice, dictionary lenses work identically to lenses on hashes. The @racket[dict-ref-lens]
+lens constructor creates a lens with a view that is the value associated with the lens's key.
+
+@(lens-interaction
+  (lens-transform (dict-ref-lens 'b)
+                  '((a . 1)
+                    (b . 2))
+                  (λ (x) (* x 2))))

--- a/lens/private/scribblings/guide/built-in/key-value.scrbl
+++ b/lens/private/scribblings/guide/built-in/key-value.scrbl
@@ -20,14 +20,14 @@ of these structures by their keys are provided.
 
 Racket hash tables are simple key-value associations, and as a result, they only have one primitive
 lens constructor, @racket[hash-ref-lens]. Given a key, it produces a lens which views the value
-associated with the lens:
+associated with the key:
 
 @(lens-interaction
   (lens-transform (hash-ref-lens 'a) (hash 'a "Hello")
                   (λ (s) (string-append s ", world!"))))
 
 Note that @racket[hash-ref-lens]'s signature differs from that of @racket[hash-ref] in an important
-way: it does not accept a "failure result" if the key is missing from the hash. Instead, the lens
+way: it does not accept a “failure result” if the key is missing from the hash. Instead, the lens
 always throws an error:
 
 @(lens-interaction
@@ -56,7 +56,7 @@ define our own hash lens that accepts a default value:
     (make-lens (λ (h)   (hash-ref h key failure-result))
                (λ (h v) (hash-set h key v)))))
 
-With this custom, "naughty" lens, we can actually perform the example from above:
+With this custom, “naughty” lens, we can actually perform the example from above:
 
 @(interaction #:eval ref-default-eval
   (let ([l (hash-ref-lens/default 'not-a-key "default")]

--- a/lens/private/scribblings/guide/built-in/ordered.scrbl
+++ b/lens/private/scribblings/guide/built-in/ordered.scrbl
@@ -1,0 +1,107 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../../doc-util/main.rkt")
+
+@(define make-lens-eval
+   (make-eval-factory '(racket/base racket/function racket/list racket/stream lens)))
+
+@(define-syntax-rule (lens-interaction expr ...)
+   (interaction #:eval (make-lens-eval) expr ...))
+
+@title[#:tag "ordered-data-lenses"]{Lenses on Ordered Data}
+
+Many Racket data structures hold @emph{ordered} or @emph{sequential} values. Lenses for accessing
+elements of these structures by index are provided.
+
+@section[#:tag "pair-list-guide"]{Pairs and Lists}
+
+@see-reference-note["pair-list-reference"]{pair and list lenses}
+
+The two primitive pair lenses are @racket[car-lens] and @racket[cdr-lens]:
+
+@(lens-interaction
+  (lens-transform car-lens '(1 . 2) (curry * 2))
+  (lens-transform cdr-lens '(1 . 2) (curry * 2)))
+
+Obviously, these also work with lists, but most of the time, it's easier to use list-specific lenses.
+For arbitrary access to elements within a list, use the @racket[list-ref-lens] lens constructor, which
+produces a new lens given an index to look up. Abbreviation lenses such as @racket[first-lens] and
+@racket[second-lens] are provided for common use-cases:
+
+@(lens-interaction
+  (lens-transform (list-ref-lens 3) (range 10) sub1)
+  (lens-transform third-lens (range 10) sub1))
+
+Using @racket[list-ref-lens], it is possible to create a lens that performs indexed lookups for nested
+lists:
+
+@(lens-interaction
+  (define (2d-list-ref-lens x y)
+    (lens-compose (list-ref-lens x)
+                  (list-ref-lens y)))
+  (lens-set (2d-list-ref-lens 1 2)
+            '((1 2 3)
+              (4 5 6)
+              (7 8 9))
+            0))
+
+This can also be generalized to @emph{n}-dimensional lists:
+
+@(lens-interaction
+  (define (list-ref-lens* . indicies)
+    (apply lens-compose (map list-ref-lens indicies)))
+  (lens-set (list-ref-lens* 0 1 0)
+            '(((a b) (c d))
+              ((e f) (g h)))
+            'z))
+
+This function is actually provided by @racketmodname[lens] under the name
+@racket[list-ref-nested-lens], but it's easy to implement yourself.
+
+@subsection{Fetching multiple list values at once}
+
+Sometimes it can be useful to fetch multiple values from a list with a single lens. This can be done
+with @racket[lens-join/list], which combines multiple lenses whose target is a single value and
+produces a new lens whose view is all of those values.
+
+@(lens-interaction
+  (define first-two-lens (lens-join/list first-lens second-lens))
+  (lens-view first-two-lens '(1 2 3 4))
+  (lens-set first-two-lens '(1 2 3 4) '(a b))
+  (lens-transform first-two-lens '(1 2 3 4) (curry map sub1)))
+
+This can be useful to implement a form of information hiding, in which only a portion of a list is
+provided to client code, but the result can still be used to update the original list.
+
+@section[#:tag "vectors-strings-guide"]{Vectors and Strings}
+
+@other-reference-note{
+  The @secref["vectors-reference"] and @secref["strings-reference"] sections in The Lens Reference
+  have additional information on vector and string lenses, respectively.}
+
+Lenses for random-access retrieval and functional update on vectors and strings are similar to the
+lenses provided for lists, but unlike lists, they are truly random-access. The
+@racket[vector-ref-lens] and @racket[string-ref-lens] lens constructors produce random-access lenses,
+and @racket[lens-join/vector] and @racket[lens-join/string] combine multiple lenses with vector or
+string targets.
+
+@(lens-interaction
+  (lens-transform (vector-ref-lens 1) #("a" "b" "c") string->symbol)
+  (lens-transform (string-ref-lens 3) "Hello!" char-upcase))
+
+@section[#:tag "streams-guide"]{Streams}
+
+@see-reference-note["streams-reference"]{stream lenses}
+
+Racket's @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{streams} contain ordered data,
+much like lists, but unlike lists, they are @emph{lazy}. Lenses on streams are similarly lazy, only
+forcing the stream up to what is necessary. This allows stream lenses to successfully operate on
+infinite streams.
+
+@(lens-interaction
+  (lens-view (stream-ref-lens 10)
+             (stream-map (curry expt 2) (in-naturals))))
+
+Keep in mind that since @racket[lens-transform] is strict, using it to update a value within a stream
+will force the stream up to the position of the element being modified.

--- a/lens/private/scribblings/guide/built-in/ordered.scrbl
+++ b/lens/private/scribblings/guide/built-in/ordered.scrbl
@@ -14,7 +14,7 @@
 Many Racket data structures hold @emph{ordered} or @emph{sequential} values. Lenses for accessing
 elements of these structures by index are provided.
 
-@section[#:tag "pair-list-guide"]{Pairs and Lists}
+@section[#:tag "pair-list-guide" #:style 'quiet]{Pairs and Lists}
 
 @see-reference-note["pair-list-reference"]{pair and list lenses}
 

--- a/lens/private/scribblings/guide/built-in/ordered.scrbl
+++ b/lens/private/scribblings/guide/built-in/ordered.scrbl
@@ -1,3 +1,4 @@
+
 #lang scribble/manual
 
 @(require scribble/eval
@@ -33,8 +34,8 @@ produces a new lens given an index to look up. Abbreviation lenses such as @rack
   (lens-transform (list-ref-lens 3) (range 10) sub1)
   (lens-transform third-lens (range 10) sub1))
 
-Using @racket[list-ref-lens], it is possible to create a lens that performs indexed lookups for nested
-lists:
+This is useful, but it only works for flat lists. However, using lens composition, it is possible to
+create a lens that performs indexed lookups for nested lists using only @racket[list-ref-lens]:
 
 @(lens-interaction
   (define (2d-list-ref-lens x y)
@@ -57,7 +58,7 @@ This can also be generalized to @emph{n}-dimensional lists:
             'z))
 
 This function is actually provided by @racketmodname[lens] under the name
-@racket[list-ref-nested-lens], but it's easy to implement yourself.
+@racket[list-ref-nested-lens], but the above example demonstrates that it's really a derived concept.
 
 @subsection{Fetching multiple list values at once}
 

--- a/lens/private/scribblings/guide/introduction.scrbl
+++ b/lens/private/scribblings/guide/introduction.scrbl
@@ -8,19 +8,19 @@
 @title[#:tag "lens-intro"]{Introduction to Lenses}
 
 The @racketmodname[lens] library defines @lens-tech{lenses}, tools for extracting values from
-potentially-nested data structures. Lenses are mostly useful when writing in a functional style, such
-as the style employed by @emph{How to Design Programs}, in which data structures are immutable and
+potentially-nested data structures. Lenses are most useful when writing in a functional style, such as
+the style employed by @italic{How to Design Programs}, in which data structures are immutable and
 side-effects are kept to a minimum.
 
 @section{What are lenses?}
 
-A @deftech[#:key "lens" #:normalize? #f]{lens} is a value that composes getter and setter functions to
-produce a bidirectional view into a data structure. This definition is intentionally broad---lenses
+A @deftech[#:key "lens" #:normalize? #f]{lens} is a value that composes a getter and a setter function
+to produce a bidirectional view into a data structure. This definition is intentionally broad---lenses
 are a very general concept, and they can be applied to almost any kind of value that encapsulates
 data. To make the concept more concrete, consider one of Racket's most primitive datatypes, the
 @tech[#:doc '(lib "scribblings/guide/guide.scrbl")]{pair}. Pairs are constructed from two values using
-@racket[cons]: the first value is retrieved using @racket[car], and the second is retrieved using
-@racket[cdr].
+the @racket[cons] function; the first value can then be retrieved using @racket[car], and the second
+can be retrieved using @racket[cdr].
 
 @(interaction
   (define p (cons 1 2))
@@ -28,11 +28,11 @@ data. To make the concept more concrete, consider one of Racket's most primitive
   (car p)
   (cdr p))
 
-With these three primitives, it's very easy to create new pairs and extract values from existing
-pairs. However, it's a little bit harder to update a single field from an existing pair. In a
-traditional Scheme, this could be accomplished by using @racket[set-car!] or @racket[set-cdr!], but
-these @emph{mutate} the original pair. To remain functional, we want to produce an @emph{entirely new}
-pair with one of the fields updated.
+With these three primitives, it's very easy to create new pairs and subsequently extract values from
+them. However, it's a little bit harder to update a single field in an existing pair. In a traditional
+Scheme, this could be accomplished by using @racket[set-car!] or @racket[set-cdr!], but these
+@emph{mutate} the original pair. To remain functional, we want to produce an @emph{entirely new} pair
+with one of the fields updated.
 
 Fortunately, this is quite easy to implement in Racket:
 
@@ -50,8 +50,8 @@ Fortunately, this is quite easy to implement in Racket:
 
 This means that each field now has a pair of getters and setters: @racket[car]/@racket[set-car] and
 @racket[cdr]/@racket[set-cdr]. A lens just wraps up each of these pairs of functions into a single
-value, so instead of having four functions, we would just have @racket[car-lens] and
-@racket[cdr-lens]. And in fact, using the functions we've just written, we can implement these lenses
+value, so instead of having four functions, we would just have two lenses: @racket[car-lens] and
+@racket[cdr-lens]. In fact, using the functions we've just written, we can implement these lenses
 ourselves.
 
 @(interaction #:eval introduction-eval
@@ -65,21 +65,25 @@ To use a lens's getter function, use @racket[lens-view]. To use the setter funct
   (lens-view car-lens (cons 1 2))
   (lens-set car-lens (cons 1 2) 'x))
 
-This, of course, isn't very useful, since we could just use the functions on their own. One thing we
-do get when using lenses is @racket[lens-transform]. This allows you to provide a procedure which will
-update the “view” based on its existing value. For example, we could increment one element in a pair:
+This, of course, isn't very useful, since we could just use the functions on their own. One extra
+thing we @emph{do} get for free when using lenses is @racket[lens-transform]. This allows you to
+provide a procedure which will update the “view” based on its existing value. For example, we could
+increment one element in a pair:
 
 @(interaction #:eval introduction-eval
   (lens-transform cdr-lens (cons 1 2) add1))
 
+While that's kind of cool, it still probably isn't enough to justify using lenses instead of just
+using functions.
+
 @section[#:style 'quiet]{Why use lenses?}
 
-So far, lenses just seem like a way to group getters and setters, and as we've seen, that's all they
-really are. However, on their own, this wouldn't be very useful. Using @racket[(car _p)] is a lot
-easier than using @racket[(lens-view car-lens _p)].
+So far, lenses just seem like a way to group getters and setters, and as we've seen, that's really all
+they are. However, on their own, this wouldn't be very useful. Using @racket[(car _p)] is a lot easier
+than using @racket[(lens-view car-lens _p)].
 
 Using plain functions starts to get a lot harder, though, once you start nesting data structures. For
-example, consider a tree structure with pairs nested inside of pairs:
+example, consider a tree constructed by nesting pairs inside of pairs:
 
 @(interaction #:eval introduction-eval
   (define tree (cons (cons 'a 'b)
@@ -113,8 +117,8 @@ than that. How can we solve it?
 @other-reference-note{For more ways to construct compound lenses, see @secref{composing-lenses}.}
 
 In order to solve this problem, we can use @emph{lens composition}, which is similar to function
-composition but extended to lenses. Just as we can create a compound getter with the expression
-@racket[(compose cdr car)], we can create a compound lens with the expression
+composition but extended to lenses. Just as we can create a compound getter function with the
+expression @racket[(compose cdr car)], we can create a compound lens with the expression
 @racket[(lens-compose cdr-lens car-lens)]. With this, we produce an entirely new lens that can be used
 with @racket[lens-view], @racket[lens-set], and @racket[lens-transform], all of which do what you
 would expect:
@@ -125,7 +129,7 @@ would expect:
   (lens-set cdar-lens tree 'x)
   (lens-transform cdar-lens tree symbol->string))
 
-Now it may begin to crystallize why lenses are useful: they make it possible to not just get at but
-to actually functionally update and transform values within deeply-nested data structures. Since they
-are composable, it is easy to create lenses that can traverse any set of structures with nothing but
-a small set of primitives. This library provides those primitives.
+Now the reason lenses are useful may begin to crystallize: they make it possible to not just get at
+but to actually functionally update and transform values within deeply-nested data structures. Since
+they are composable, it is easy to create lenses that can traverse any set of structures with nothing
+but a small set of primitives. This library provides those primitives.

--- a/lens/private/scribblings/guide/introduction.scrbl
+++ b/lens/private/scribblings/guide/introduction.scrbl
@@ -72,7 +72,7 @@ update the “view” based on its existing value. For example, we could increme
 @(interaction #:eval introduction-eval
   (lens-transform cdr-lens (cons 1 2) add1))
 
-@section{Why use lenses?}
+@section[#:style 'quiet]{Why use lenses?}
 
 So far, lenses just seem like a way to group getters and setters, and as we've seen, that's all they
 really are. However, on their own, this wouldn't be very useful. Using @racket[(car _p)] is a lot

--- a/lens/private/scribblings/guide/introduction.scrbl
+++ b/lens/private/scribblings/guide/introduction.scrbl
@@ -1,0 +1,131 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../doc-util/main.rkt")
+
+@(define introduction-eval ((make-eval-factory '(racket/base lens))))
+
+@title[#:tag "lens-intro"]{Introduction to Lenses}
+
+The @racketmodname[lens] library defines @lens-tech{lenses}, tools for extracting values from
+potentially-nested data structures. Lenses are mostly useful when writing in a functional style, such
+as the style employed by @emph{How to Design Programs}, in which data structures are immutable and
+side-effects are kept to a minimum.
+
+@section{What are lenses?}
+
+A @deftech[#:key "lens" #:normalize? #f]{lens} is a value that composes getter and setter functions to
+produce a bidirectional view into a data structure. This definition is intentionally broad---lenses
+are a very general concept, and they can be applied to almost any kind of value that encapsulates
+data. To make the concept more concrete, consider one of Racket's most primitive datatypes, the
+@tech[#:doc '(lib "scribblings/guide/guide.scrbl")]{pair}. Pairs are constructed from two values using
+@racket[cons]: the first value is retrieved using @racket[car], and the second is retrieved using
+@racket[cdr].
+
+@(interaction
+  (define p (cons 1 2))
+  p
+  (car p)
+  (cdr p))
+
+With these three primitives, it's very easy to create new pairs and extract values from existing
+pairs. However, it's a little bit harder to update a single field from an existing pair. In a
+traditional Scheme, this could be accomplished by using @racket[set-car!] or @racket[set-cdr!], but
+these @emph{mutate} the original pair. To remain functional, we want to produce an @emph{entirely new}
+pair with one of the fields updated.
+
+Fortunately, this is quite easy to implement in Racket:
+
+@(interaction #:eval introduction-eval
+  (define (set-car p v)
+    (cons v (cdr p)))
+  (define (set-cdr p v)
+    (cons (car p) v))
+  (set-car (cons 1 2) 'x)
+  (set-cdr (cons 1 2) 'y))
+
+@other-reference-note{
+ Both @racket[car-lens] and @racket[cdr-lens], are provided by @racketmodname[lens] out of the box,
+ along with some other shorthand lenses. For the full list, see @secref{pair-lenses}.}
+
+This means that each field now has a pair of getters and setters: @racket[car]/@racket[set-car] and
+@racket[cdr]/@racket[set-cdr]. A lens just wraps up each of these pairs of functions into a single
+value, so instead of having four functions, we would just have @racket[car-lens] and
+@racket[cdr-lens]. And in fact, using the functions we've just written, we can implement these lenses
+ourselves.
+
+@(interaction #:eval introduction-eval
+  (define car-lens (make-lens car set-car))
+  (define cdr-lens (make-lens cdr set-cdr)))
+
+To use a lens's getter function, use @racket[lens-view]. To use the setter function, use
+@racket[lens-set]:
+
+@(interaction #:eval introduction-eval
+  (lens-view car-lens (cons 1 2))
+  (lens-set car-lens (cons 1 2) 'x))
+
+This, of course, isn't very useful, since we could just use the functions on their own. One thing we
+do get when using lenses is @racket[lens-transform]. This allows you to provide a procedure which will
+update the “view” based on its existing value. For example, we could increment one element in a pair:
+
+@(interaction #:eval introduction-eval
+  (lens-transform cdr-lens (cons 1 2) add1))
+
+@section{Why use lenses?}
+
+So far, lenses just seem like a way to group getters and setters, and as we've seen, that's all they
+really are. However, on their own, this wouldn't be very useful. Using @racket[(car _p)] is a lot
+easier than using @racket[(lens-view car-lens _p)].
+
+Using plain functions starts to get a lot harder, though, once you start nesting data structures. For
+example, consider a tree structure with pairs nested inside of pairs:
+
+@(interaction #:eval introduction-eval
+  (define tree (cons (cons 'a 'b)
+                     (cons 'c 'd))))
+
+Now, getting at a nested value gets much harder. It's necessary to nest calls to get at the right
+value:
+
+@(interaction #:eval introduction-eval
+  (cdr (car tree)))
+
+Still, this isn't too bad. However, what if we want to @emph{set} a value? We could use our
+@racket[set-car] and @racket[set-cdr] functions from earlier, but if we try, we'll find they don't
+work quite right:
+
+@(interaction #:eval introduction-eval
+  (set-cdr (car tree) 'x))
+
+Oops. We wanted to get back the whole tree, but we just got back one of the internal nodes because
+we used @racket[set-cdr] on that node. In order to actually do what we want, we'd need to add a lot
+more complexity:
+
+@(interaction #:eval introduction-eval
+  (set-car tree (set-cdr (car tree) 'x)))
+
+That's what we need to do just for @emph{one} level of nesting---it would be much worse for any more
+than that. How can we solve it?
+
+@subsection{Lens composition}
+
+@other-reference-note{For more ways to construct compound lenses, see @secref{composing-lenses}.}
+
+In order to solve this problem, we can use @emph{lens composition}, which is similar to function
+composition but extended to lenses. Just as we can create a compound getter with the expression
+@racket[(compose cdr car)], we can create a compound lens with the expression
+@racket[(lens-compose cdr-lens car-lens)]. With this, we produce an entirely new lens that can be used
+with @racket[lens-view], @racket[lens-set], and @racket[lens-transform], all of which do what you
+would expect:
+
+@(interaction #:eval introduction-eval
+  (define cdar-lens (lens-compose cdr-lens car-lens))
+  (lens-view cdar-lens tree)
+  (lens-set cdar-lens tree 'x)
+  (lens-transform cdar-lens tree symbol->string))
+
+Now it may begin to crystallize why lenses are useful: they make it possible to not just get at but
+to actually functionally update and transform values within deeply-nested data structures. Since they
+are composable, it is easy to create lenses that can traverse any set of structures with nothing but
+a small set of primitives. This library provides those primitives.

--- a/lens/private/scribblings/guide/user-defined.scrbl
+++ b/lens/private/scribblings/guide/user-defined.scrbl
@@ -1,0 +1,12 @@
+#lang scribble/manual
+
+@title[#:tag "user-defined-lenses" #:style 'toc]{Lenses on User-Defined Datatypes}
+
+In addition to the built-in lenses, @racketmodname[lens] provides utilities for construcing new lenses
+for user-defined datatypes. This section covers the utilities for creating lenses for Racket structs,
+as well as the general lens constructors for making arbitrary lenses.
+
+@local-table-of-contents[]
+
+@include-section["user-defined/struct.scrbl"]
+@include-section["user-defined/custom.scrbl"]

--- a/lens/private/scribblings/guide/user-defined/custom.scrbl
+++ b/lens/private/scribblings/guide/user-defined/custom.scrbl
@@ -1,0 +1,49 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../../doc-util/main.rkt")
+
+@(define make-lens-eval
+   (make-eval-factory '(racket/base lens)))
+@(define-syntax-rule (lens-interaction expr ...)
+   (interaction #:eval (make-lens-eval) expr ...))
+
+@(define construct-eval (make-lens-eval))
+@(define-syntax-rule (construct-interaction expr ...)
+   (interaction #:eval construct-eval expr ...))
+
+@title[#:tag "construction-guide"]{Constructing Entirely New Lenses}
+
+Sometimes the existing set of lenses isn't enough. Perhaps you have a particularly unique data
+structure, and you want to create a lens for it. Perhaps you just want to provide lenses for your
+custom data structures, and struct lenses aren't good enough. In that case, it's always possible to
+fall back on the primitive lens constructor, @racket[make-lens].
+
+The @racket[make-lens] constructor is simple---it creates a new lens from a getter function and a
+(functional) setter function. That's it. A lens is nothing more than that.
+
+As an example, it would actually be possible to implement lenses for complex numbers: one lens for the
+real part and a second lens for the imaginary part. Implementing these lenses is fairly simple---we
+just need to write getters and setters for each portion of the number:
+
+@(construct-interaction
+  (define real-lens
+    (make-lens real-part
+               (λ (n r) (make-rectangular (real-part r) (imag-part n)))))
+  (define imag-lens
+    (make-lens imag-part
+               (λ (n i) (make-rectangular (real-part n) (real-part i))))))
+
+In this case, Racket already provides the getters for us: @racket[real-part] and @racket[imag-part].
+We need to implement the setters ourselves, which we can do using @racket[make-rectangular]. Now we
+can actually do math on separate components of numbers using @racket[lens-transform]:
+
+@(construct-interaction
+  (lens-transform real-lens 2+3i (λ (x) (* x 2)))
+  (lens-transform imag-lens 2+3i (λ (x) (* x 2))))
+
+When creating a lens with @racket[make-lens], it's important to make sure it also follows the
+@seclink["laws"]{lens laws}. These are simple requirements to ensure that your custom lens behaves
+intuitively. Lenses that do @emph{not} adhere to these laws will most likely cause unexpected
+behavior. However, as long as your lens plays by the rules, it will automatically work with all the
+other lens functions, including lens combinators like @racket[lens-compose].

--- a/lens/private/scribblings/guide/user-defined/custom.scrbl
+++ b/lens/private/scribblings/guide/user-defined/custom.scrbl
@@ -16,7 +16,7 @@
 
 Sometimes the existing set of lenses isn't enough. Perhaps you have a particularly unique data
 structure, and you want to create a lens for it. Perhaps you just want to provide lenses for your
-custom data structures, and struct lenses aren't good enough. In that case, it's always possible to
+custom data structures, and struct lenses are insufficient. In that case, it's always possible to
 fall back on the primitive lens constructor, @racket[make-lens].
 
 The @racket[make-lens] constructor is simple---it creates a new lens from a getter function and a

--- a/lens/private/scribblings/guide/user-defined/struct.scrbl
+++ b/lens/private/scribblings/guide/user-defined/struct.scrbl
@@ -1,0 +1,75 @@
+#lang scribble/manual
+
+@(require scribble/eval
+          "../../../doc-util/main.rkt")
+
+@(define make-lens-eval
+   (make-eval-factory '(racket/base lens)))
+@(define-syntax-rule (lens-interaction expr ...)
+   (interaction #:eval (make-lens-eval) expr ...))
+
+@(define struct-eval (make-lens-eval))
+@(define-syntax-rule (struct-interaction expr ...)
+   (interaction #:eval struct-eval expr ...))
+
+@title[#:tag "struct-guide"]{Structures}
+
+@see-reference-note["struct-reference"]{struct lenses}
+
+Racket's structure system is an extremely useful tool to help model your problem domain, but using
+them in a functional style can be laborious. To make this easier, @racketmodname[lens] provides helper
+macros to automatically generate lenses for structure fields, which can be composed just like any
+other lenses to allow easy functional programming with nested structs.
+
+To start using lenses with structs, use the @racket[struct/lens] form when defining a structure
+instead of @racket[struct]:
+
+@(struct-interaction
+  (struct/lens point (x y) #:transparent))
+
+This will define a struct called @racket[point], and it will also produce two lenses,
+@racket[point-x-lens] and @racket[point-y-lens]. It's also possible to define lenses for an
+@emph{existing} structure type using @racket[define-struct-lenses].
+
+@(lens-interaction
+  (struct point (x y) #:transparent)
+  (define-struct-lenses point))
+
+If you don't want to use the auto-definition behavior of @racket[struct/lens] or
+@racket[define-struct-lenses], you can also use @racket[struct-lens] to create one-off lenses for
+particular fields.
+
+@(lens-interaction
+  (struct point (x y) #:transparent)
+  (struct-lens point x))
+
+One created, structure lenses work just like any other lenses: they can be used with functions like
+@racket[lens-view], @racket[lens-set], and @racket[lens-transform], and they can be composed with
+other lenses to produce new ones.
+
+@(struct-interaction
+  (lens-view point-x-lens (point 4 10))
+  (lens-set point-y-lens (point 4 10) 15)
+  (lens-transform point-x-lens (point 4 10)
+                  (λ (x) (* x 3))))
+
+Composition of struct lenses can make it much easier to write purely functional state transformations,
+such as the “world programs” of @italic{How to Design Programs}. For example, given some state:
+
+@(struct-interaction
+  (struct/lens world (play-time player-stats) #:transparent)
+  (struct/lens player-stats (health attack) #:transparent)
+  (struct/lens monster (attack) #:transparent))
+
+It's possible to write updater functions that manipulate nested state without completely destructuring
+and rebuilding the structure each time:
+
+@(struct-interaction
+  (define (perform-monster-attack world monster)
+    (lens-transform (lens-compose player-stats-health-lens
+                                  world-player-stats-lens)
+                    world
+                    (λ (hp) (- hp (monster-attack monster)))))
+  (let ([w (world 0 (player-stats 15 6))]
+        [m (monster 2)])
+    (perform-monster-attack w m)))

--- a/lens/private/scribblings/reference.scrbl
+++ b/lens/private/scribblings/reference.scrbl
@@ -1,0 +1,16 @@
+#lang scribble/manual
+
+@title[#:tag "lens-reference"]{The Lens Reference}
+
+@local-table-of-contents[]
+
+@include-section["../base/main.scrbl"]
+@include-section["../compound/main.scrbl"]
+@include-section["../list/main.scrbl"]
+@include-section["../hash/main.scrbl"]
+@include-section["../struct/main.scrbl"]
+@include-section["../vector/main.scrbl"]
+@include-section["../string.scrbl"]
+@include-section["../stream.scrbl"]
+@include-section["../dict.scrbl"]
+@include-section["../../applicable.scrbl"]

--- a/lens/private/stream.scrbl
+++ b/lens/private/stream.scrbl
@@ -3,7 +3,9 @@
 @(require "doc-util/main.rkt")
 
 
-@title{Stream Lenses}
+@title[#:tag "streams-reference"]{Stream Lenses}
+
+@see-guide-note["streams-guide"]{stream lenses}
 
 @defthing[stream-first-lens lens?]{
 A lens for viewing the first element of a stream.

--- a/lens/private/string.scrbl
+++ b/lens/private/string.scrbl
@@ -2,7 +2,7 @@
 
 @(require "doc-util/main.rkt")
 
-@title{String Lenses}
+@title[#:tag "strings-reference"]{String Lenses}
 
 @defproc[(string-ref-lens [i exact-nonnegative-integer?]) lens?]{
 Returns a lens for viewing the @racket[i]th character of a string.

--- a/lens/private/struct/main.scrbl
+++ b/lens/private/struct/main.scrbl
@@ -1,8 +1,11 @@
 #lang scribble/manual
 
-@(require "../doc-util/scribble-include-no-subsection.rkt")
+@(require "../doc-util/main.rkt"
+          "../doc-util/scribble-include-no-subsection.rkt")
 
-@title{Struct Lenses}
+@title[#:tag "struct-reference"]{Struct Lenses}
+
+@see-guide-note["struct-guide"]{struct lenses}
 
 @scribble-include/no-subsection["field.scrbl"]
 @scribble-include/no-subsection["struct.scrbl"]

--- a/lens/private/vector/main.scrbl
+++ b/lens/private/vector/main.scrbl
@@ -2,7 +2,7 @@
 
 @(require "../doc-util/scribble-include-no-subsection.rkt")
 
-@title{Vector lenses}
+@title[#:tag "vectors-reference"]{Vector lenses}
 
 @scribble-include/no-subsection["ref.scrbl"]
 @scribble-include/no-subsection["nested.scrbl"]


### PR DESCRIPTION
This adds an initial base for a “lens guide” that can be a companion to the “lens reference,” similar to the relationship between The Racket Guide and The Racket Reference. The idea is to make lenses more accessible to programmers that are new to them, as well as to try and motivate the actual use-case for lenses by describing the problems they’re attempting to solve and demonstrating how they solve them.

Please feel free to look over what I’ve written to ensure the validity of what I’ve said, and feel free to suggest editing changes. I’ve tried to add cross-references between the reference and the guide where appropriate, but if you think I missed some, feel free to point them out, too.

I think this is by no means perfect, and there are lots more topics that one might reasonably want a guide to lenses to cover. Some of the other things I’ve considered are:
- Creating a sort of “recipes” section that shows snippets of how to apply lenses in real code.
- Elaborating more on the lens laws and providing justification for each, with examples of what can occur when they are violated.
- Giving examples of using lenses with `big-bang` programs.

I think it’s a good start, though, and we can try to improve it as time goes on.
