### PR TITLE
Add at-exp-lib as a build dependency

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -22,7 +22,8 @@
 
 
 (define build-deps
-  '("cover"
+  '("at-exp-lib"
+    "cover"
     "rackunit-lib"
     "racket-doc"
     "jack-scribble-example"


### PR DESCRIPTION
Looks like I forgot to add this, but it’s needed now that I used `#lang at-exp` in doc-util.
