### PR TITLE
Remove unstable sub collection definitions from docs

### DIFF
--- a/unstable/lens/arrow.scrbl
+++ b/unstable/lens/arrow.scrbl
@@ -4,16 +4,14 @@
 
 @title{lens-view/thrush, lens-set/thrush, and lens-transform/thrush}
 
-@defmodule[unstable/lens/arrow]
-
 @deftogether[[@defproc[(lens-view/thrush [target any/c] [lens lens?] ...) any/c]
               @defproc[(lens-view~> [target any/c] [lens lens?] ...) any/c]]]{
 Like @racket[lens-view], except that it can take multiple lenses,
 which are combined into a nested lens. The argument order is
-switched, so that the @racket[target] comes first and the		
-@racket[lens] arguments come after it.		
-@racket[(lens-view/thrush target lens ...)] produces the same value as		
-@racket[(lens-view (lens-thrush lens ...) target)], but can be more		
+switched, so that the @racket[target] comes first and the
+@racket[lens] arguments come after it.
+@racket[(lens-view/thrush target lens ...)] produces the same value as
+@racket[(lens-view (lens-thrush lens ...) target)], but can be more
 efficient.
 The function @racket[lens-view~>] is provided as a shorter version.
 @lens-unstable-examples[
@@ -24,7 +22,7 @@ The function @racket[lens-view~>] is provided as a shorter version.
 @deftogether[[@defproc[(lens-set/thrush [target any/c] [lens lens?] ... [#:-> new-view any/c]) any/c]
               @defproc[(lens-set~> [target any/c] [lens lens?] ... [#:-> new-view any/c]) any/c]]]{
 Like @racket[lens-set], except that it can take multiple lenses,
-which again are combined into a nested lens. 	
+which again are combined into a nested lens.
 @racket[(lens-set/thrush target lens ... #:-> new-view)] is equivalent
 to @racket[(lens-set (lens-thrush lens ...) target new-view)], and
 @racket[lens-set~>] is the shorter version.
@@ -40,7 +38,7 @@ to @racket[(lens-set (lens-thrush lens ...) target new-view)], and
                                          [#:-> transformer (-> any/c any/c)])
                        any/c]]]{
 Like @racket[lens-transform], except that it can take multiple lenses,
-just like @racket[lens-set/thrush].	
+just like @racket[lens-set/thrush].
 @racket[(lens-transform/thrush target lens ... #:-> transformer)] is
 equivalent to
 @racket[(lens-transform (lens-thrush lens ...) target transformer)],
@@ -49,4 +47,3 @@ and @racket[lens-transform~>] is the shorter verison.
   (lens-transform/thrush '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> symbol->string)
   (lens-transform~> '(a b ((c d) e f) g) third-lens first-lens second-lens #:-> symbol->string)
 ]}
-

--- a/unstable/lens/define-nested.scrbl
+++ b/unstable/lens/define-nested.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lenses for nested data}
 
-@defmodule[unstable/lens/define-nested]
-
 @defform[(define-nested-lenses [base-id base-lens-expr] clause ...)
          #:grammar ([clause [sub-id sub-lens-expr]])]{
 A shorthand for defining composed lenses for nested data structures.

--- a/unstable/lens/dict-nested.scrbl
+++ b/unstable/lens/dict-nested.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lenses for nested dictionaries}
 
-@defmodule[unstable/lens/dict-nested]
-
 @defproc[(dict-ref-nested-lens [k any/c] ...) (lens/c functional-dict? any/c)]{
 Similar to @racket[hash-ref-nested-lens], but for dicts.
 @lens-unstable-examples[

--- a/unstable/lens/hash-filterer.scrbl
+++ b/unstable/lens/hash-filterer.scrbl
@@ -4,8 +4,6 @@
 
 @title{Filtering hash-tables}
 
-@defmodule[unstable/lens/hash-filterer]
-
 @defproc[(hash-filterer-lens/key [keep? (-> any/c boolean?)])
          (lens/c immutable-hash? immutable?)]{
 Creates a lens that filters a hash-table to keys that pass the predicate
@@ -32,4 +30,3 @@ takes the key and the value as its two arguments.
   (lens-view (hash-filterer-lens =) (hash 1 1.0 2 45 3 3))
   (lens-set (hash-filterer-lens =) (hash 1 1.0 2 45 3 3) (hash 4 4.0 5.0 5))
 ]}
-

--- a/unstable/lens/if.scrbl
+++ b/unstable/lens/if.scrbl
@@ -4,8 +4,6 @@
 
 @title{Conditional Lenses}
 
-@defmodule[unstable/lens/if]
-
 @defproc[(lens-if [pred (-> target/c any/c)]
                   [lens1 (lens/c target/c view/c)]
                   [lens2 (lens/c target/c view/c)])

--- a/unstable/lens/isomorphism.scrbl
+++ b/unstable/lens/isomorphism.scrbl
@@ -4,8 +4,6 @@
 
 @title{Isomorphisms}
 
-@defmodule[unstable/lens/isomorphism]
-
 @defproc[(make-isomorphism-lens [f (a/c . -> . b/c)] [inv (b/c . -> . a/c)]) lens?]{
 Creates a lens for an isomorphism. The @racket[f] argument should be a function
 with an inverse, and the @racket[inv] argument should be its inverse.

--- a/unstable/lens/join-assoc.scrbl
+++ b/unstable/lens/join-assoc.scrbl
@@ -4,8 +4,6 @@
 
 @title{Joining lenses with an association list}
 
-@defmodule[unstable/lens/join-assoc]
-
 @defproc[(lens-join/assoc [key key/c] [lens (lens/c target/c value/c)] ... ...)
          (lens/c target/c (listof (cons/c key/c value/c)))]{
 Like @racket[lens-join/hash], except joins the keys and values into an

--- a/unstable/lens/lazy.scrbl
+++ b/unstable/lens/lazy.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lazy lenses and recursive lenses}
 
-@defmodule[unstable/lens/lazy]
-
 @defform[(lazy-lens lens-expr)]{
 Creates a lazy lens that lazily evaluates @racket[lens-expr] and uses it to view
 and set the target.
@@ -30,4 +28,3 @@ Creates a potentially recursive lens, where @racket[lens-expr] can refer to
             '(a (b (() c)) (d))
             '("hay" ("bee" (() "sea")) ("deep")))
 ]}
-

--- a/unstable/lens/map.scrbl
+++ b/unstable/lens/map.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lenses that map over lists and vectors}
 
-@defmodule[unstable/lens/map]
-
 @defproc[(map-lens [lens lens?]) lens?]{
 Creates a lens that maps @racket[lens] over a target list.
 @lens-unstable-examples[

--- a/unstable/lens/set-filterer.scrbl
+++ b/unstable/lens/set-filterer.scrbl
@@ -4,8 +4,6 @@
 
 @title{Filtering sets}
 
-@defmodule[unstable/lens/set-filterer]
-
 @defproc[(set-filterer-lens [pred (-> any/c any/c)]) (lens/c functional-set? functional-set?)]{
 Creates a lens that filters a set by the predicate @racket[pred].
 @lens-unstable-examples[

--- a/unstable/lens/set-member.scrbl
+++ b/unstable/lens/set-member.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lenses for membership of a set}
 
-@defmodule[unstable/lens/set-member]
-
 @defproc[(set-member-lens [v any/c]) (lens/c functional-set? boolean?)]{
 Creates a lens for telling whether @racket[v] is a member of the target set.
 @lens-unstable-examples[
@@ -17,4 +15,3 @@ Creates a lens for telling whether @racket[v] is a member of the target set.
   (lens-set 2-lens (set 1 3) #t)
   (lens-set 2-lens (set 1 3) #f)
 ]}
-

--- a/unstable/lens/string-split.scrbl
+++ b/unstable/lens/string-split.scrbl
@@ -4,8 +4,6 @@
 
 @title{Splitting Strings}
 
-@defmodule[unstable/lens/string-split]
-
 @defproc[(string-split-lens [sep (or/c string? char? regexp?)]) lens?]{
 Creates a lens that splits a string into multiple pieces like
 @racket[regexp-split] or @racket[string-split].

--- a/unstable/lens/struct-join.scrbl
+++ b/unstable/lens/struct-join.scrbl
@@ -4,14 +4,12 @@
 
 @title{Joining lenses with structs}
 
-@defmodule[unstable/lens/struct-join]
-
 @defform[(lens-join/struct struct-id field-lens ...)
          #:grammar ([field-lens (code:line lens-expr)
                                 (code:line field-keyword lens-expr)])]{
 Like @racket[lens-join/list], except that the views of the given
 lenses are put in an instance of the @racket[struct-id] struct instead
-of in a list. 
+of in a list.
 @lens-unstable-examples[
   (struct foo (a b) #:transparent)
   (define lens (lens-join/struct foo first-lens third-lens))

--- a/unstable/lens/struct-nested.scrbl
+++ b/unstable/lens/struct-nested.scrbl
@@ -4,8 +4,6 @@
 
 @title{Nested struct lenses}
 
-@defmodule[unstable/lens/struct-nested]
-
 @(persistent-lens-unstable-examples struct-nested-examples)
 
 @defform[#:id struct-nested-lens

--- a/unstable/lens/struct-provide.scrbl
+++ b/unstable/lens/struct-provide.scrbl
@@ -4,8 +4,6 @@
 
 @title{Struct-lens provide forms}
 
-@defmodule[unstable/lens/struct-provide]
-
 @defform[(struct-lenses-out struct-id)]{
 A @racket[provide] sub-form that provides the lenses defined by
 @racket[define-struct-lenses] or @racket[struct/lens].

--- a/unstable/lens/sublist.scrbl
+++ b/unstable/lens/sublist.scrbl
@@ -4,8 +4,6 @@
 
 @title{Sublist lenses}
 
-@defmodule[unstable/lens/sublist]
-
 @defproc[(sublist-lens [i exact-nonnegative-integer?] [j exact-nonnegative-integer?]) lens?]{
 @lens-unstable-examples[
   (lens-view (sublist-lens 1 4) '(0 1 2 3 4 5))

--- a/unstable/lens/syntax.scrbl
+++ b/unstable/lens/syntax.scrbl
@@ -5,8 +5,6 @@
 
 @title{Syntax Lenses}
 
-@defmodule[unstable/lens/syntax]
-
 @defform[(syntax-lens target-id structure)]{
   Constructs a lens that parses a syntax object and returns
   a piece of that syntax object as determined by where

--- a/unstable/lens/zoom.scrbl
+++ b/unstable/lens/zoom.scrbl
@@ -4,8 +4,6 @@
 
 @title{Lenses that transform subpieces}
 
-@defmodule[unstable/lens/zoom]
-
 @defproc[(lens-zoom [zoom-lens lens?] [transform-lens lens?]) lens?]{
 Creates a lens that transforms the subpiece of the target that @racket[zoom-lens]
 views with @racket[transform-lens].


### PR DESCRIPTION
Closes #248

Doesn't implement reproviding of lens from unstable/lens, realized that was a bad idea as most use cases require both lens and unstable/lens rather than either lens or unstable/lens.

This also doesn't move things into a /private directory, to preserve backwards compatibility.
