### PR TITLE
use the struct-update package instead of alexis/util/struct

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -14,8 +14,9 @@
     "unstable-list-lib"
     "unstable-contract-lib"
     "fancy-app"
-    "alexis-util"
-    "sweet-exp"
+    "syntax-classes-lib"
+    "struct-update-lib"
+    "sweet-exp-lib"
     "kw-make-struct"
     "reprovide-lang"
     "scribble-lib"))

--- a/lens/private/struct/field.rkt
+++ b/lens/private/struct/field.rkt
@@ -2,7 +2,7 @@
 
 (require racket/local
          syntax/parse/define
-         alexis/util/struct
+         struct-update
          "../base/main.rkt"
          (for-syntax racket/base
                      syntax/parse


### PR DESCRIPTION
This removes the dependency on `alexis-util` and replaces it with dependencies on `struct-update-lib` and `syntax-classes-lib`. It uses `struct-update-lib` for `define-struct-updaters`, and it uses `syntax-classes-lib` for getting the accessors from a `struct-id` that aren't come from a super-struct.
