### PR TITLE
merge lens and unstable/lens docs into one document

### DIFF
--- a/lens-doc/lens/main.scrbl
+++ b/lens-doc/lens/main.scrbl
@@ -22,3 +22,4 @@ source code: @url["https://github.com/jackfirth/lens"]
 
 @include-section["private/scribblings/guide.scrbl"]
 @include-section["private/scribblings/reference.scrbl"]
+@include-section[(lib "unstable/lens/main.scrbl")]

--- a/lens-doc/lens/private/doc-util/deflenses.rkt
+++ b/lens-doc/lens/private/doc-util/deflenses.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require scribble/manual
-         (for-label lens/private/base/main))
+         (for-label lens))
 
 (provide deflens
          deflenses)

--- a/lens-doc/unstable/info.rkt
+++ b/lens-doc/unstable/info.rkt
@@ -1,4 +1,0 @@
-#lang info
-
-(define scribblings '(["lens/main.scrbl" () (experimental) "unstable-lens"]))
-


### PR DESCRIPTION
So that the package server displays one documentation link for the `lens` package, pointing to a page that has both in one multi-page scribble file.
