### PR TITLE
Preserve the distinction between #'(a . (b c)) and #'(a b c) in stx lenses

### DIFF
--- a/lens-doc/lens/private/syntax/stx.scrbl
+++ b/lens-doc/lens/private/syntax/stx.scrbl
@@ -4,6 +4,15 @@
 
 @title{Syntax object lenses based on @racketmodname[syntax/stx]}
 
+The lenses in this section preserve the distinction between syntax pairs and
+syntax lists, e.g.
+@RACKETBLOCK[(lens-set stx->list-lens #'(UNSYNTAX @tt{(a . (b c))}) '(1 2 3))]
+will have the same structure as
+@RACKETBLOCK[#'(UNSYNTAX @tt{(1 . (2 3))})]
+If the distinction between syntax pairs and syntax lists were not preserved,
+the result would instead be:
+@RACKETBLOCK[#'(UNSYNTAX @tt{(1 2 3)})]
+
 @defthing[stx->list-lens lens?]{
 A lens that views a stx-list as a list. Viewing with this lens is
 equivalent to using @racket[stx->list], and if the target is a syntax


### PR DESCRIPTION
Syntax lenses lack some amount of “Get-Set Consistency”, because `(lens-set L T (lens-view L T))` where `L` is `stx->list-lens` and `T` is `#'(a . (b c))` will, with the current implementation, produce a syntax object equivalent to `#' (a b c)` instead of the preferable `#'(a . (b c))`.

This PR should fix this problem for lenses which depend on `restore-stx`.
