### PR TITLE
add isomorphism-cond and isomorphism-join

### DIFF
--- a/lens-common/lens/private/isomorphism/compound.rkt
+++ b/lens-common/lens/private/isomorphism/compound.rkt
@@ -7,15 +7,22 @@ provide
       (rest-> isomorphism-lens? isomorphism-lens?)
     isomorphism-thrush
       (rest-> isomorphism-lens? isomorphism-lens?)
+  isomorphism-cond
+  isomorphism-join
 
 require racket/match
         lens/private/util/rest-contract
+        syntax/parse/define
         "base.rkt"
+        for-syntax
+          racket/base
 module+ test
   require lens/private/base/main
           lens/private/compound/identity
           lens/private/isomorphism/data
           rackunit
+
+;; ------------------------------------------------------------------------
 
 (define (isomorphism-compose . args)
   (match args
@@ -26,6 +33,118 @@ module+ test
 
 (define (isomorphism-thrush . args)
   (apply isomorphism-compose (reverse args)))
+
+;; -----------------------------------------------------------------------
+
+(define-simple-macro
+  (isomorphism-cond [pred-a? iso-a->b pred-b?] ...)
+  #:with [a->b ...] (generate-temporaries #'[iso-a->b ...])
+  #:with [b->a ...] (generate-temporaries #'[iso-a->b ...])
+  (match-let ([(make-isomorphism-lens a->b b->a) iso-a->b] ...)
+    (make-isomorphism-lens
+     (λ (a)
+       (cond [(pred-a? a) (check (a->b a) pred-b?)]
+             ...
+             [else (error 'isomorphism-cond)]))
+     (λ (b)
+       (cond [(pred-b? b) (check (b->a b) pred-a?)]
+             ...
+             [else (error 'isomorphism-cond)])))))
+
+(define (check val pred?)
+  (unless (pred? val)
+    (error 'bi-cond "promised a value passing ~v, given ~v" pred? val))
+  val)
+
+;; -----------------------------------------------------------------------
+
+;; |---------------------------------------------------------------------|
+;; | (isomorphism-join                                                   |
+;; |   make-a                                                            |
+;; |   make-b                                                            |
+;; |   [a-selector  iso-a-piece->b-piece  b-selector]                    |
+;; |   ...)                                                              |
+;; | -> [Isomorphism A B]                                                |
+;; | where:                                                              |
+;; |   make-a     : A-Piece ... -> A                                     |
+;; |   make-b     : B-Piece ... -> B                                     |
+;; |   a-selector : A -> A-Piece                                         |
+;; |   ...                                                               |
+;; |   b-selector : B -> B-Piece                                         |
+;; |   ...                                                               |
+;; |   iso-a-piece->b-piece : [Isomorphism A-Piece B-Piece]              |
+;; |   ...                                                               |
+;; |---------------------------------------------------------------------|
+;;
+;; In order for this to be a valid isomorphism, each piece isomorphism must
+;; be a valid isomorphism between the piece types, and these properties
+;; must be true for all a, b, a-piece..., and b-piece...:
+;; (make-a (a-selector a) ...) = a
+;; (make-b (b-selector b) ...) = b
+;; (a-selector (make-a a-piece ...)) = a-piece
+;; ...
+;; (b-selector (make-b b-piece ...)) = b-piece
+;; ...
+
+(define-simple-macro
+  (isomorphism-join mk-a mk-b [a-sel iso-piece b-sel] ...)
+  #:with [a-selector ...] (generate-temporaries #'[a-sel ...])
+  #:with [b-selector ...] (generate-temporaries #'[b-sel ...])
+  #:with [ap->bp ...] (generate-temporaries #'[iso-piece ...])
+  #:with [bp->ap ...] (generate-temporaries #'[iso-piece ...])
+  (match-let ([make-a mk-a]
+              [make-b mk-b]
+              [a-selector a-sel] ...
+              [b-selector b-sel] ...
+              [(make-isomorphism-lens ap->bp bp->ap) iso-piece] ...)
+    (make-isomorphism-lens
+     (λ (a)
+       (make-b (ap->bp (a-selector a)) ...))
+     (λ (b)
+       (make-a (bp->ap (b-selector b)) ...)))))
+
+;; What are (inv (f a)) and (f (inv b))?
+;; Context:
+;; C1. (make-a (a-selector a) ...) = a
+;; C2. (make-b (b-selector b) ...) = b
+;; C3. (a-selector (make-a a-piece ...)) = a-piece
+;;     ...
+;; C4. (b-selector (make-b b-piece ...)) = b-piece
+;;     ...
+;; C5. (b-piece->a-piece (a-piece->b-piece a-piece)) = a-piece
+;;     ...
+;; C6. (a-piece->b-piece (b-piece->a-piece b-piece)) = b-piece
+;;     ...
+
+;; Proof for (inv (f a)) = a:
+;;   (inv (f a))
+;; =   {Def. f}
+;;   (inv (make-b (a-piece->b-piece (a-selector a)) ...))
+;; =   {Def. inv}
+;;   let b = (make-b (a-piece->b-piece (a-selector a)) ...)
+;;   in (make-a (b-piece->a-piece (b-selector b)) ...)
+;; =   {C4}
+;;   (make-a (b-piece->a-piece (a-piece->b-piece (a-selector a))) ...)
+;; =   {C5}
+;;   (make-a (a-selector a) ...)
+;; =   {C1}
+;;   a
+
+;; Proof for (f (inv b)) = b:
+;;   (f (inv b))
+;; =   {Def. inv}
+;;   (f (make-a (b-piece->a-piece (b-selector b)) ...))
+;; =   {Def. f}
+;;   let a = (make-a (b-piece->a-piece (b-selector b)) ...)
+;;   in (make-b (a-piece->b-piece (a-selector a)) ...)
+;; =   {C3}
+;;   (make-b (a-piece->b-piece (b-piece->a-piece (b-selector b))) ...)
+;; =   {C6}
+;;   (make-b (b-selector b) ...)
+;; =   {C2}
+;;   b
+
+;; -----------------------------------------------------------------------
 
 module+ test
   (define string->vector-lens (isomorphism-thrush string->list-lens list->vector-lens))

--- a/lens-common/lens/private/isomorphism/lazy.rkt
+++ b/lens-common/lens/private/isomorphism/lazy.rkt
@@ -1,0 +1,54 @@
+#lang sweet-exp racket/base
+
+provide lazy-isomorphism
+        rec-isomorphism
+
+require fancy-app
+        lens/private/base/main
+        racket/match
+        racket/promise
+        "base.rkt"
+module+ test
+  require rackunit
+          racket/list
+          lens/private/compound/identity
+          lens/private/isomorphism/data
+          "compound.rkt"
+
+(define-syntax-rule (lazy-isomorphism expr)
+  (let ([iso (delay expr)])
+    (make-isomorphism-lens
+     (λ (a) (match (force iso) [(make-isomorphism-lens f _) (f a)]))
+     (λ (b) (match (force iso) [(make-isomorphism-lens _ inv) (inv b)])))))
+
+(define-syntax-rule (rec-isomorphism name expr)
+  (letrec ([name (lazy-isomorphism expr)])
+    name))
+
+module+ test
+  (define (map-iso item-iso)
+    (rec-isomorphism the-map-iso
+      (isomorphism-cond
+        [empty?  identity-lens  empty?]
+        [cons?
+         (isomorphism-join
+           cons
+           cons
+           [first  item-iso     first]
+           [rest   the-map-iso  rest])
+         cons?])))
+  ;
+  (define (tree-map-iso a? item-iso b?)
+    (rec-isomorphism the-tree-iso
+      (isomorphism-cond
+        [list? (map-iso the-tree-iso) list?]
+        [a? item-iso b?])))
+  ;
+  (check-equal? (lens-view (tree-map-iso symbol? symbol->string-lens string?)
+                           '(a (b (() c)) (d)))
+                '("a" ("b" (() "c")) ("d")))
+  (check-equal? (lens-set (tree-map-iso symbol? symbol->string-lens string?)
+                          '(a (b (() c)) (d))
+                          '("hay" ("bee" (() "sea")) ("deep")))
+                '(hay (bee (() sea)) (deep)))
+


### PR DESCRIPTION
This pull request adds `isomorphism-cond`, `isomorphism-join`, `lazy-isomorphism`, and `rec-isomorphism`.

TODO: Add docs.

Examples:
```racket
(define (map-iso item-iso)
  (rec-isomorphism the-map-iso
    (isomorphism-cond
      [empty?  identity-lens  empty?]
      [cons?
       (isomorphism-join
         cons
         cons
         [first  item-iso     first]
         [rest   the-map-iso  rest])
       cons?])))

(define (tree-map-iso a? item-iso b?)
  (rec-isomorphism the-tree-iso
    (isomorphism-cond
      [a? item-iso b?]
      [list? (map-iso the-tree-iso) list?])))
 
;; Converts between a base 4 number represented as a list of digits
;; (least significant first, most significant last) and a number.
(define base4->number-iso
  (lazy-isomorphism
   (isomorphism-cond
     [empty?  (const-isomorphism '() 0)  zero?]
     [cons?
      (isomorphism-join
        cons
        (λ (r q) (+ (* 4 q) r))
        [first  identity-isomorphism  (curryr remainder 4)]
        [rest   base4->number-iso     (curryr quotient 4)])
      positive?])))
```