### PR TITLE
lens-join/list only follows lens laws when views of args don't overlap

### DIFF
--- a/lens-data/lens/private/list/join-list.rkt
+++ b/lens-data/lens/private/list/join-list.rkt
@@ -36,11 +36,13 @@ provide
 ;; and
 ;; each X-piece is a valid view for X-piece-lens
 
-;; If the views of the X-piece-lenses don't overlap, then for every X-piece...:
-;; (lens-view X-piece-lens (lens-set/list X {X-piece-lens X-piece} ...))
+;; If the views of the X-piece-lenses don't overlap, then for every combination
+;; of X-pieces, A and B:
+;; (lens-set B-lens (lens-set A-lens X A) B)
 ;; =
-;; X-piece
+;; (lens-set A-lens (lens-set B-lens X B) A)
 ;; ...
+;; In other words, lens-set operations for the X-piece-lenses "commute."
 
 ;; Context:
 ;; C1:   {lens laws for X-piece-lens}
@@ -51,7 +53,13 @@ provide
 ;;     ...
 ;; C3:   {Def. lens-set/list, repeated application of C1}
 ;;     (lens-set/list X {X-piece-lens (lens-view X-piece-lens X)} ...) = X
-;; C4:   {assumption that X-piece-lenses don't overlap}
+;; C4.   {assumption that X-piece-lenses don't overlap}
+;;     For every combination of X-Pieces, A and B:
+;;     (lens-set B-lens (lens-set A-lens X A) B)
+;;     =
+;;     (lens-set A-lens (lens-set B-lens X B) A)
+;;     ...
+;; C5:   {repeated application of C4, C2}
 ;;     (lens-view X-piece-lens (lens-set/list X {X-piece-lens X-piece} ...))
 ;;     =
 ;;     X-piece
@@ -80,7 +88,7 @@ provide
 ;;   in (list
 ;;       (lens-view X-piece-lens Y)
 ;;       ...)
-;; =   {C4}
+;; =   {C5}
 ;;   (list X-piece ...)
 ;; =   {Def. X-pieces}
 ;;   X-pieces

--- a/lens-data/lens/private/list/join-list.rkt
+++ b/lens-data/lens/private/list/join-list.rkt
@@ -15,6 +15,8 @@ provide
   contract-out
     lens-join/list (rest-> lens? (lens/c any/c list?))
 
+;; The joined lens only follows the lens laws if the views of the argument
+;; lenses don't overlap.
 
 (define (lens-join/list . lenses)
   (define (get target)
@@ -23,6 +25,65 @@ provide
     (apply lens-set/list target (keys+values->alternating-list lenses new-views)))
   (make-lens get set))
 
+;; joined-lens = (lens-join/list X-piece-lens ...)
+
+;; For joined-lens to follow the lens laws, these properties have to hold for
+;; all X and X-pieces:
+;; (joined-set X (joined-get X)) = X
+;; (joined-get (joined-set X X-pieces)) = X-pieces
+;; where:
+;; X-pieces = (list X-piece ...)
+;; and
+;; each X-piece is a valid view for X-piece-lens
+
+;; If the views of the X-piece-lenses don't overlap, then for every X-piece...:
+;; (lens-view X-piece-lens (lens-set/list X {X-piece-lens X-piece} ...))
+;; =
+;; X-piece
+;; ...
+
+;; Context:
+;; C1:   {lens laws for X-piece-lens}
+;;     (lens-set X-piece-lens X (lens-view X-piece-lens X)) = X
+;;     ...
+;; C2:   {lens laws for X-piece-lens}
+;;     (lens-view X-piece-lens (lens-set X X-piece-lens X-piece)) = X-piece
+;;     ...
+;; C3:   {Def. lens-set/list, repeated application of C1}
+;;     (lens-set/list X {X-piece-lens (lens-view X-piece-lens X)} ...) = X
+;; C4:   {assumption that X-piece-lenses don't overlap}
+;;     (lens-view X-piece-lens (lens-set/list X {X-piece-lens X-piece} ...))
+;;     =
+;;     X-piece
+;;     ...
+
+;; Proof for (joined-set X (joined-get X)) = X:
+;;   (joined-set X (joined-get X))
+;; =   {Def. joined-get}
+;;   (joined-set X (lens-view/list X X-piece-lens ...))
+;; =   {Def. lens-view/list}
+;;   (joined-set X (list (lens-view X-piece-lens X) ...))
+;; =   {Def. joined-set}
+;;   (lens-set/list X {X-piece-lens (lens-view X-piece-lens X)} ...)
+;; =   {C3}
+;;   X
+
+;; Proof for (joined-get (joined-set X X-pieces)) = X-pieces:
+;;   (joined-get (joined-set X X-pieces))
+;; =   {Def. joined-set, Def. X-pieces}
+;;   (joined-get (lens-set/list X {X-piece-lens X-piece} ...))
+;; =   {Def. joined-get}
+;;   let Y = (lens-set/list X {X-piece-lens X-piece} ...)
+;;   in (lens-view/list Y X-piece-lens ...)
+;; =   {Def. lens-view/list}
+;;   let Y = (lens-set/list X {X-piece-lens X-piece} ...)
+;;   in (list
+;;       (lens-view X-piece-lens Y)
+;;       ...)
+;; =   {C4}
+;;   (list X-piece ...)
+;; =   {Def. X-pieces}
+;;   X-pieces
 
 (module+ test
   (define first-third-fifth-lens

--- a/lens-data/lens/private/list/join-list.rkt
+++ b/lens-data/lens/private/list/join-list.rkt
@@ -38,11 +38,9 @@ provide
 
 ;; If the views of the X-piece-lenses don't overlap, then for every combination
 ;; of X-pieces, A and B:
-;; (lens-set B-lens (lens-set A-lens X A) B)
-;; =
-;; (lens-set A-lens (lens-set B-lens X B) A)
-;; ...
-;; In other words, lens-set operations for the X-piece-lenses "commute."
+;; if (lens-view A-lens X) = A,
+;; then (lens-view A-lens (lens-set B-lens X B)) = A.
+;; In other words, setting B can't change the view of A.
 
 ;; Context:
 ;; C1:   {lens laws for X-piece-lens}
@@ -55,11 +53,11 @@ provide
 ;;     (lens-set/list X {X-piece-lens (lens-view X-piece-lens X)} ...) = X
 ;; C4.   {assumption that X-piece-lenses don't overlap}
 ;;     For every combination of X-Pieces, A and B:
-;;     (lens-set B-lens (lens-set A-lens X A) B)
-;;     =
-;;     (lens-set A-lens (lens-set B-lens X B) A)
+;;     (lens-view A-lens X) = A
+;;     =>
+;;     (lens-view A-lens (lens-set B-lens X B)) = A
 ;;     ...
-;; C5:   {repeated application of C4, C2}
+;; C5:   {C2, repeated application of C4}
 ;;     (lens-view X-piece-lens (lens-set/list X {X-piece-lens X-piece} ...))
 ;;     =
 ;;     X-piece

--- a/lens-doc/lens/private/list/join-list.scrbl
+++ b/lens-doc/lens/private/list/join-list.scrbl
@@ -8,8 +8,12 @@
   Constructs a lens that combines the view of each
   @racket[lens] into a list of views. This lens can
   be used to view and set a list of values in a single
-  target. If any of the lenses share views, then when
-  setting the later lenses override the earlier ones.
+  target.
+
+  The joined lens only follows the
+  @seclink["laws"]{lens laws} if the views of the
+  argument lenses don't overlap.
+
   @lens-examples[
     (define first-third-fifth-lens
       (lens-join/list first-lens

--- a/lens-doc/lens/private/list/join-list.scrbl
+++ b/lens-doc/lens/private/list/join-list.scrbl
@@ -12,7 +12,9 @@
 
   The joined lens only follows the
   @seclink["laws"]{lens laws} if the views of the
-  argument lenses don't overlap.
+  argument lenses don't overlap. Views of the lenses
+  overlap when setting one can change the view of
+  another lens.
 
   @lens-examples[
     (define first-third-fifth-lens


### PR DESCRIPTION
Fixes `lens-join/list` for #301, by specifying that the joined lens only follows the lens laws if the views of the argument lenses don't overlap.