### PR TITLE
strengthen "Last Set Wins" lens law

### DIFF
--- a/lens-common/lens/private/test-util/test-lens.rkt
+++ b/lens-common/lens/private/test-util/test-lens.rkt
@@ -34,11 +34,11 @@
                    "view of target after setting it's view not equal? to the set view"))
 
 (define-check (check-lens-set-set lens target new-view1 new-view2)
-  (let* ([target* (lens-set lens target new-view1)]
-         [target** (lens-set lens target* new-view2)])
-    (check-lens-view lens target**
-                     new-view2
-                     "view of target after setting its view twice not equal? to second view")))
+  (let* ([target/1  (lens-set lens target new-view1)]
+         [target/12 (lens-set lens target/1 new-view2)]
+         [target/2  (lens-set lens target new-view2)])
+    (check-equal? target/12 target/2
+      "target after setting view twice not equal? to setting to second view")))
 
 (define (test-lens-laws lens test-target test-view1 test-view2)
   (check-lens-view-set lens test-target)

--- a/lens-doc/lens/private/base/laws.scrbl
+++ b/lens-doc/lens/private/base/laws.scrbl
@@ -52,10 +52,14 @@ and setters "ought" to work. The laws for lenses are:
     two views @racket[v-first] and @racket[v-second] of @racket[L],
     the expression
     @racketblock[
-      (lens-view L (lens-set L (lens-set L T v-first) v-second))
+      (lens-set L (lens-set L T v-first) v-second)
     ]
-    must be equal to @racket[v-second] with respect to a reasonable
-    definition of equality for views of @racket[L].
+    must be equal to
+    @racketblock[
+      (lens-set L T v-second)
+    ]
+    with respect to a reasonable definition of equality for targets
+    of @racket[L].
   }
 ]
 
@@ -69,4 +73,4 @@ All lenses provided by this library are proper unless otherwise
 stated. There is no enforcement or contract that lenses constructed
 with functions from this library will always be proper, but individual
 functions may provide conditional guarantees about their interactions
-with improper lenses and the lens laws
+with improper lenses and the lens laws.


### PR DESCRIPTION
Fixes #304, changes the "Last Set Wins" lens law into:
```racket
  (lens-set L (lens-set L T V1) V2)
=
  (lens-set L T V2)
```