### PR TITLE
 Update dependency on kw-make-struct

### DIFF
--- a/lens-data/info.rkt
+++ b/lens-data/info.rkt
@@ -10,7 +10,7 @@
     "fancy-app"
     "syntax-classes-lib"
     "struct-update-lib"
-    "kw-make-struct"
+    "kw-make-struct-lib"
     "reprovide-lang-lib"
     ))
 


### PR DESCRIPTION
This changes a dependency from `kw-make-struct` to `kw-make-struct-lib`, to avoid an unnecessary transitive dependency on `racket-doc`. This is an addition to #307 